### PR TITLE
Feat/#40 manage token

### DIFF
--- a/BongBaek/BongBaek/Global/AppStateManager.swift
+++ b/BongBaek/BongBaek/Global/AppStateManager.swift
@@ -6,23 +6,81 @@
 //
 
 import SwiftUI
+import Combine
 
 enum AppState {
     case launch
     case login
-//    case signUp
     case main
 }
 
+@MainActor
 class AppStateManager: ObservableObject {
     @Published var currentState: AppState = .launch
     @Published var authData: AuthData?
     @Published var showSignUpSheet = false
+    private let authManager = AuthManager.shared
+    private var cancellables = Set<AnyCancellable>()
+    
+    init() {
+        setupAuthStateObserver()
+    }
+    
+    private func setupAuthStateObserver() {
+        authManager.$authState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] authState in
+                self?.handleAuthStateChange(authState)
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func handleAuthStateChange(_ authState: AuthManager.AuthState) {
+        switch authState {
+        case .loading:
+            // 로딩 상태는 현재 상태 유지
+            break
+            
+        case .authenticated:
+            withAnimation {
+                currentState = .main
+                showSignUpSheet = false
+            }
+            
+        case .needsLogin:
+            withAnimation {
+                currentState = .login
+                showSignUpSheet = false
+            }
+            
+        case .needsSignUp:
+            // 회원가입이 필요한 경우 시트 표시
+            withAnimation {
+                showSignUpSheet = true
+            }
+        }
+    }
+    
+    func checkAuthStatus() {
+        // 앱 시작 시 인증 상태 확인
+        authManager.checkAuthStatus()
+    }
+    
     
     func moveToLogin() {
         withAnimation {
             currentState = .login
         }
+    }
+    
+    func loginWithKakao() {
+        Task {
+            await authManager.loginWithKakao()
+        }
+    }
+    
+    func signUp(memberInfo: MemberInfo) {
+        authManager.signUp(memberInfo: memberInfo)
     }
     
     func handleLoginResult(_ authData: AuthData) {
@@ -42,8 +100,22 @@ class AppStateManager: ObservableObject {
     func completeSignUp() {
         withAnimation {
             currentState = .main
+            showSignUpSheet = false
         }
     }
+    
+    func logout() {
+        authManager.logout()
+    }
+    
+    var isAuthenticated: Bool {
+        return authManager.isAuthenticated
+    }
+    
+    var hasValidTokens: Bool {
+        return authManager.hasValidTokens
+    }
+
 }
 
 

--- a/BongBaek/BongBaek/Info.plist
+++ b/BongBaek/BongBaek/Info.plist
@@ -26,6 +26,11 @@
 		<string>kakaokompassauth</string>
 		<string>kakaolink</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Black.otf</string>

--- a/BongBaek/BongBaek/Network/Base/AuthError.swift
+++ b/BongBaek/BongBaek/Network/Base/AuthError.swift
@@ -1,0 +1,33 @@
+//
+//  AuthError.swift
+//  BongBaek
+//
+//  Created by 임재현 on 7/14/25.
+//
+
+import Foundation
+
+enum AuthError: Error {
+    case keychainError
+    case tokenNotFound
+    case tokenExpired
+    case networkError
+    case loginFailed
+    case logoutFailed
+    case notLoggedIn
+    case invalidData
+    
+    var localizedDescription: String {
+        switch self {
+        case .keychainError: return "키체인 저장/읽기 실패"
+        case .tokenNotFound: return "토큰이 존재하지 않습니다"
+        case .tokenExpired: return "토큰이 만료되었습니다"
+        case .networkError: return "네트워크 오류"
+        case .loginFailed: return "로그인에 실패했습니다."
+        case .logoutFailed: return "로그아웃에 실패했습니다."
+        case .notLoggedIn: return "로그인이 필요합니다"
+        case .invalidData: return "유효하지 않은 데이터"
+            
+        }
+    }
+}

--- a/BongBaek/BongBaek/Network/Base/AuthManager.swift
+++ b/BongBaek/BongBaek/Network/Base/AuthManager.swift
@@ -13,6 +13,7 @@ class AuthManager: ObservableObject {
     static let shared = AuthManager()
     
     @Published var authState: AuthState = .loading
+    @Published var currentKakaoId: Int? = nil
     
     private let authService: AuthServiceProtocol
     private let keychainManager = KeychainManager.shared
@@ -80,7 +81,7 @@ class AuthManager: ObservableObject {
                 receiveCompletion: { [weak self] completion in
                     if case .failure(let error) = completion {
                         print("회원가입 실패: \(error)")
-                        self?.authState = .needsSignUp
+//                        self?.authState = .needsSignUp
                     }
                 },
                 receiveValue: { [weak self] response in
@@ -153,6 +154,9 @@ class AuthManager: ObservableObject {
             authState = .needsLogin
             return
         }
+        
+        currentKakaoId = authData.kakaoId
+        print("저장된 kakaoId: \(currentKakaoId ?? 0)")
         
         // 회원가입 완료 여부 먼저 확인
         if authData.isCompletedSignUp {
@@ -266,6 +270,14 @@ class AuthManager: ObservableObject {
             print("토큰 업데이트 실패: \(error)")
             logout()
         }
+    }
+    
+    func getCurrentKakaoId() -> String {
+        guard let kakaoId = currentKakaoId else {
+            print("kakaoId가 없습니다. 로그인이 필요할 수 있습니다.")
+            return "0"
+        }
+        return String(kakaoId)
     }
 }
 

--- a/BongBaek/BongBaek/Network/Base/AuthManager.swift
+++ b/BongBaek/BongBaek/Network/Base/AuthManager.swift
@@ -1,0 +1,244 @@
+//
+//  AuthManager.swift
+//  BongBaek
+//
+//  Created by 임재현 on 7/14/25.
+//
+
+import Foundation
+import Combine
+
+@MainActor
+class AuthManager: ObservableObject {
+    static let shared = AuthManager()
+    
+    @Published var authState: AuthState = .loading
+    
+    private let authService: AuthServiceProtocol
+    private let keychainManager = KeychainManager.shared
+
+    private var cancellables = Set<AnyCancellable>()
+    
+    private init() {
+        self.authService = DIContainer.shared.authService
+    }
+    
+    
+    enum AuthState {
+        case loading
+        case authenticated
+        case needsLogin
+        case needsSignUp
+    }
+    
+    // MARK: - 카카오 로그인 후 처리
+    func loginWithKakao(kakaoToken: String) {
+        authState = .loading
+        
+        authService.login(accessToken: kakaoToken)
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: { [weak self] completion in
+                    if case .failure(let error) = completion {
+                        print("로그인 실패: \(error)")
+                        self?.authState = .needsLogin
+                    }
+                },
+                receiveValue: { [weak self] response in
+                    self?.handleLoginResponse(response)
+                }
+            )
+            .store(in: &cancellables)
+    }
+    
+    // MARK: - 회원가입
+    func signUp(memberInfo: MemberInfo) {
+        authState = .loading
+        
+        authService.signUp(memberInfo: memberInfo)
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: { [weak self] completion in
+                    if case .failure(let error) = completion {
+                        print("회원가입 실패: \(error)")
+                        self?.authState = .needsSignUp
+                    }
+                },
+                receiveValue: { [weak self] response in
+                    self?.handleSignUpResponse(response)
+                }
+            )
+            .store(in: &cancellables)
+    }
+    
+    // MARK: - 자동 로그인
+    func checkAuthStatus() {
+        guard let accessToken = keychainManager.accessToken else {
+            authState = .needsLogin
+            return
+        }
+        
+        // 저장된 토큰으로 자동 로그인 시도
+        // 여기서는 토큰이 있으면 일단 authenticated로 처리
+        authState = .authenticated
+        
+        // TODO: 실제로는 토큰 유효성 검증 API 호출
+        // validateToken(accessToken)
+    }
+    
+    // MARK: - 토큰 갱신
+    func refreshTokens() {
+        guard let refreshToken = keychainManager.refreshToken else {
+            logout()
+            return
+        }
+        
+        authService.retryToken()
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: { [weak self] completion in
+                    if case .failure(let error) = completion {
+                        print("토큰 갱신 실패: \(error)")
+                        self?.logout()
+                    }
+                },
+                receiveValue: { [weak self] response in
+                    self?.handleRefreshTokenResponse(response)
+                }
+            )
+            .store(in: &cancellables)
+    }
+    
+    // MARK: - 로그아웃
+    func logout() {
+        let result = keychainManager.clearTokens()
+        if case .failure(let error) = result {
+            print("토큰 삭제 실패: \(error)")
+        }
+        authState = .needsLogin
+    }
+    
+    // MARK: - Private Response Handlers
+    
+    private func handleLoginResponse(_ response: LoginResponse) {
+        // BaseResponse 성공 여부 확인
+        guard response.isSuccess else {
+            print("로그인 API 실패: \(response.message)")
+            authState = .needsLogin
+            return
+        }
+        
+        // AuthData 확인
+        guard let authData = response.data else {
+            print("로그인 응답 데이터가 없습니다")
+            authState = .needsLogin
+            return
+        }
+        
+        // TokenInfo 확인 및 저장
+        guard let tokenInfo = authData.token else {
+            print("토큰 정보가 없습니다")
+            authState = .needsLogin
+            return
+        }
+        
+        // 키체인에 토큰 저장
+        let saveResult = keychainManager.saveTokens(
+            access: tokenInfo.accessToken,
+            refresh: tokenInfo.refreshToken
+        )
+        
+        switch saveResult {
+        case .success:
+            // 회원가입 완료 여부에 따라 상태 결정
+            authState = authData.isCompletedSignUp ? .authenticated : .needsSignUp
+            print("로그인 성공, 회원가입 완료: \(authData.isCompletedSignUp)")
+            
+        case .failure(let error):
+            print("토큰 저장 실패: \(error)")
+            authState = .needsLogin
+        }
+    }
+    
+    private func handleSignUpResponse(_ response: SignUpResponse) {
+        // BaseResponse 성공 여부 확인
+        guard response.isSuccess else {
+            print("회원가입 API 실패: \(response.message)")
+            authState = .needsSignUp
+            return
+        }
+        
+        // AuthData 확인
+        guard let authData = response.data else {
+            print("회원가입 응답 데이터가 없습니다")
+            authState = .needsSignUp
+            return
+        }
+        
+        // TokenInfo 확인 및 업데이트 (회원가입 후 새로운 토큰이 올 수 있음)
+        if let tokenInfo = authData.token {
+            let saveResult = keychainManager.saveTokens(
+                access: tokenInfo.accessToken,
+                refresh: tokenInfo.refreshToken
+            )
+            
+            switch saveResult {
+            case .success:
+                authState = .authenticated
+                print("회원가입 완료 및 토큰 업데이트 성공")
+                
+            case .failure(let error):
+                print("토큰 업데이트 실패: \(error)")
+                authState = .needsSignUp
+            }
+        } else {
+            // 토큰 정보가 없어도 회원가입은 성공
+            authState = .authenticated
+            print("회원가입 완료")
+        }
+    }
+    
+    private func handleRefreshTokenResponse(_ response: RefreshTokenResponse) {
+        // BaseResponse 성공 여부 확인
+        guard response.isSuccess else {
+            print("토큰 갱신 API 실패: \(response.message)")
+            logout()
+            return
+        }
+        
+        // TokenInfo 확인
+        guard let tokenInfo = response.data else {
+            print("토큰 갱신 응답 데이터가 없습니다")
+            logout()
+            return
+        }
+        
+        // 새로운 액세스 토큰 저장
+        let updateResult = keychainManager.updateAccessToken(tokenInfo.accessToken)
+        
+        switch updateResult {
+        case .success:
+            print("토큰 갱신 성공")
+            // 상태는 유지 (이미 authenticated 상태)
+            
+        case .failure(let error):
+            print("토큰 업데이트 실패: \(error)")
+            logout()
+        }
+    }
+}
+
+// MARK: - extension
+extension AuthManager {
+    var isAuthenticated: Bool {
+        return authState == .authenticated
+    }
+    
+    var currentAccessToken: String? {
+        return keychainManager.accessToken
+    }
+    
+    var hasValidTokens: Bool {
+        return keychainManager.hasTokens()
+    }
+}

--- a/BongBaek/BongBaek/Network/Base/AuthManager.swift
+++ b/BongBaek/BongBaek/Network/Base/AuthManager.swift
@@ -135,6 +135,7 @@ class AuthManager: ObservableObject {
         if case .failure(let error) = result {
             print("토큰 삭제 실패: \(error)")
         }
+        currentKakaoId = nil
         authState = .needsLogin
     }
     

--- a/BongBaek/BongBaek/Network/Base/AuthTarget.swift
+++ b/BongBaek/BongBaek/Network/Base/AuthTarget.swift
@@ -66,11 +66,7 @@ extension AuthTarget: TargetType {
             ]
         case .signUp(let memberInfo):
             return [
-                "Content-Type": "application/json",
-                "kakaoId" : memberInfo.kakaoID,
-                "appleId" : memberInfo.appleID ?? "",
-                "memberBirthday": memberInfo.memberBirthday,
-                "memberIncome" : memberInfo.memberIncome
+                "Content-Type": "application/json"
             ]
         case .retryToken:
             let refreshToken = UserDefaults.standard.string(forKey: "refreshToken") ?? ""

--- a/BongBaek/BongBaek/Network/Base/AuthTarget.swift
+++ b/BongBaek/BongBaek/Network/Base/AuthTarget.swift
@@ -9,6 +9,10 @@ import Moya
 import Foundation
 
 
+struct LoginRequest: Codable {
+    let accessToken: String
+}
+
 enum AuthTarget {
     case login(accessToken: String)
     case signUp(memberInfo: MemberInfo)
@@ -41,15 +45,24 @@ extension AuthTarget: TargetType {
     }
     
     var task: Moya.Task {
-        return .requestPlain
+        switch self {
+        case .login(let accessToken):
+            let loginRequest = LoginRequest(accessToken: accessToken)
+            return .requestJSONEncodable(loginRequest)
+            
+        case .signUp(let memberInfo):
+            return .requestJSONEncodable(memberInfo)
+            
+        case .retryToken:
+            return .requestPlain
+        }
     }
     
     var headers: [String : String]? {
         switch self {
         case .login(let accessToken):
             return [
-                "Content-Type": "application/json",
-                "authorizationCode": accessToken
+                "Content-Type": "application/json"
             ]
         case .signUp(let memberInfo):
             return [

--- a/BongBaek/BongBaek/Network/Base/KaKaoLoginManager.swift
+++ b/BongBaek/BongBaek/Network/Base/KaKaoLoginManager.swift
@@ -1,0 +1,35 @@
+//
+//  KaKaoLoginManager.swift
+//  BongBaek
+//
+//  Created by 임재현 on 7/14/25.
+//
+
+import KakaoSDKUser
+
+class KakaoLoginManager {
+    static let shared = KakaoLoginManager()
+    private init() {}
+    
+    func login() async throws -> String {
+        return try await withCheckedThrowingContinuation { continuation in
+            if UserApi.isKakaoTalkLoginAvailable() {
+                UserApi.shared.loginWithKakaoTalk { oauthToken, error in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                    } else if let accessToken = oauthToken?.accessToken {
+                        continuation.resume(returning: accessToken)
+                    }
+                }
+            } else {
+                UserApi.shared.loginWithKakaoAccount { oauthToken, error in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                    } else if let accessToken = oauthToken?.accessToken {
+                        continuation.resume(returning: accessToken)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/BongBaek/BongBaek/Network/Base/KeyChainManager.swift
+++ b/BongBaek/BongBaek/Network/Base/KeyChainManager.swift
@@ -1,0 +1,206 @@
+//
+//  KeyChainManager.swift
+//  BongBaek
+//
+//  Created by 임재현 on 7/14/25.
+//
+
+import Foundation
+
+final class KeychainManager {
+    static let shared = KeychainManager()
+    
+    private let serviceName = Bundle.main.bundleIdentifier ?? "com.BongBaek.keychain"
+    private let accessTokenKey = "accessToken"
+    private let refreshTokenKey = "refreshToken"
+    
+    private init() {}
+    
+    
+    /// 액세스 토큰과 리프레시 토큰을 동시에 저장
+    func saveTokens(access: String, refresh: String) -> Result<Void, AuthError> {
+        switch save(key: accessTokenKey, value: access) {
+        case .success:
+            switch save(key: refreshTokenKey, value: refresh) {
+            case .success:
+                return .success(())
+            case .failure(let error):
+                // 액세스 토큰 저장 성공했지만 리프레시 토큰 실패시 롤백
+                delete(key: accessTokenKey)
+                return .failure(error)
+            }
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+    
+    /// 액세스 토큰 업데이트
+    @discardableResult
+    func updateAccessToken(_ token: String) -> Result<Void, AuthError> {
+        return save(key: accessTokenKey, value: token)
+    }
+    
+    /// 리프레시 토큰 업데이트
+    @discardableResult
+    func updateRefreshToken(_ token: String) -> Result<Void, AuthError> {
+        return save(key: refreshTokenKey, value: token)
+    }
+    
+    /// 액세스 토큰 조회
+    func getAccessToken() -> Result<String, AuthError> {
+        return load(key: accessTokenKey)
+    }
+    
+    /// 리프레시 토큰 조회
+    func getRefreshToken() -> Result<String, AuthError> {
+        return load(key: refreshTokenKey)
+    }
+    
+    /// 모든 토큰 삭제
+    @discardableResult
+    func clearTokens() -> Result<Void, AuthError> {
+        let accessResult = delete(key: accessTokenKey)
+        let refreshResult = delete(key: refreshTokenKey)
+        
+        // 둘 중 하나라도 실패하면 실패로 처리
+        switch (accessResult, refreshResult) {
+        case (.success, .success):
+            return .success(())
+        case (.failure(let error), _), (_, .failure(let error)):
+            return .failure(error)
+        }
+    }
+    
+    /// 토큰 존재 여부 확인
+    func hasTokens() -> Bool {
+        switch (getAccessToken(), getRefreshToken()) {
+        case (.success, .success):
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// 액세스 토큰 편의 프로퍼티
+    var accessToken: String? {
+        get {
+            switch getAccessToken() {
+            case .success(let token): return token
+            case .failure: return nil
+            }
+        }
+        set {
+            if let token = newValue {
+                updateAccessToken(token)
+            } else {
+                delete(key: accessTokenKey)
+            }
+        }
+    }
+    
+    /// 리프레시 토큰 편의 프로퍼티
+    var refreshToken: String? {
+        get {
+            switch getRefreshToken() {
+            case .success(let token): return token
+            case .failure: return nil
+            }
+        }
+        set {
+            if let token = newValue {
+                updateRefreshToken(token)
+            } else {
+                delete(key: refreshTokenKey)
+            }
+        }
+    }
+    
+    
+    /// 키체인에 값 저장
+    private func save(key: String, value: String) -> Result<Void, AuthError> {
+        guard let data = value.data(using: .utf8) else {
+            return .failure(.invalidData)
+        }
+        
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: key,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        ]
+        
+        let attributesToUpdate: [String: Any] = [
+            kSecValueData as String: data
+        ]
+        
+        let status: OSStatus
+        
+        // 기존 아이템이 있는지 확인
+        if SecItemCopyMatching(query as CFDictionary, nil) == errSecSuccess {
+            // 업데이트
+            status = SecItemUpdate(query as CFDictionary, attributesToUpdate as CFDictionary)
+        } else {
+            // 새로 추가
+            var newItem = query
+            newItem[kSecValueData as String] = data
+            status = SecItemAdd(newItem as CFDictionary, nil)
+        }
+        
+        return status == errSecSuccess ? .success(()) : .failure(.keychainError)
+    }
+    
+    /// 키체인에서 값 로드
+    private func load(key: String) -> Result<String, AuthError> {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        
+        guard status == errSecSuccess else {
+            return status == errSecItemNotFound ? .failure(.tokenNotFound) : .failure(.keychainError)
+        }
+        
+        guard let data = result as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            return .failure(.invalidData)
+        }
+        
+        return .success(value)
+    }
+    
+    /// 키체인에서 값 삭제
+    private func delete(key: String) -> Result<Void, AuthError> {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: key
+        ]
+        
+        let status = SecItemDelete(query as CFDictionary)
+        
+        // 성공이거나 아이템이 없었던 경우 모두 성공으로 처리
+        return (status == errSecSuccess || status == errSecItemNotFound)
+            ? .success(())
+            : .failure(.keychainError)
+    }
+}
+
+
+#if DEBUG
+extension KeychainManager {
+    /// 디버깅용 토큰 정보 출력
+    func printTokenStatus() {
+        print("=== Token Status ===")
+        print("Access Token: \(accessToken != nil ? "존재" : "없음")")
+        print("Refresh Token: \(refreshToken != nil ? "존재" : "없음")")
+        print("Has Both Tokens: \(hasTokens())")
+        print("==================")
+    }
+}
+#endif

--- a/BongBaek/BongBaek/Network/Model/Request/MemberInfo.swift
+++ b/BongBaek/BongBaek/Network/Model/Request/MemberInfo.swift
@@ -8,9 +8,25 @@
 import SwiftUI
 
 struct MemberInfo: Codable {
-    let kakaoID: String
-    let appleID: String? = nil
+    let kakaoId: Int
+    let appleId: Int?
     let memberName: String
     let memberBirthday: String
     let memberIncome: String
+    
+    enum CodingKeys: String, CodingKey {
+        case kakaoId
+        case appleId
+        case memberName
+        case memberBirthday
+        case memberIncome
+    }
+    
+    init(kakaoId: Int, appleId: Int? = nil, memberName: String, memberBirthday: String, memberIncome: String) {
+        self.kakaoId = kakaoId
+        self.appleId = appleId
+        self.memberName = memberName
+        self.memberBirthday = memberBirthday
+        self.memberIncome = memberIncome
+    }
 }

--- a/BongBaek/BongBaek/Network/Model/Request/MemberInfo.swift
+++ b/BongBaek/BongBaek/Network/Model/Request/MemberInfo.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct MemberInfo {
+struct MemberInfo: Codable {
     let kakaoID: String
     let appleID: String? = nil
     let memberName: String

--- a/BongBaek/BongBaek/Presentation/Home/View/HomeView.swift
+++ b/BongBaek/BongBaek/Presentation/Home/View/HomeView.swift
@@ -27,12 +27,21 @@ struct HomeView: View {
 
                         .frame(height: 276)
                         .padding(.top, 30)
+                    
+                    
+                    Button("로그아웃 테스트") {
+                        AuthManager.shared.logout()
+                        KeychainManager.shared.printTokenStatus()
+                    }
+                    .foregroundColor(.red)
+                    
                     RecommendsView()
                         .environmentObject(stepManager)
                         .environmentObject(router)
                         .padding(.top, 10)
                     ScheduleView(schedules: sDummy)
                         .padding(.top, 32)
+                    
                 }
 //                CustomTabView(selectedTab: $selectedTab)
 //                    .background(Color.gray750)

--- a/BongBaek/BongBaek/Presentation/Login/View/LoginView.swift
+++ b/BongBaek/BongBaek/Presentation/Login/View/LoginView.swift
@@ -34,8 +34,9 @@ struct LoginView: View {
 
                        Button(action: {
 //                           isPresented = true
-                           handleKakaoLogin()
-                           loginViewModel.loginwithKakao()
+//                           handleKakaoLogin()
+                           appStateManager.loginWithKakao()
+//                           KeychainManager.shared.clearTokens()
                            // ToDo - viewModel.kakaoLogin 시작하는 로직
                        }) {
                            Image("btn_kakao")
@@ -102,22 +103,5 @@ struct LoginView: View {
            .presentationDragIndicator(.visible)
        }
    }
-    
-    private func handleKakaoLogin() {
-        loginViewModel.isLoading = true
-        
-        // 테스트용 가짜 응답 - 실제로는 loginViewModel.kakaoLogin() 호출
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            let mockAuthData = AuthData(
-                token: TokenInfo(accessToken: "mock_access", refreshToken: "mock_refresh"),
-                isCompletedSignUp: false, // 랜덤으로 true/false 테스트
-                kakaoId: 12345,
-                kakaoAccessToken: "mock_kakao_token"
-            )
-            
-            loginViewModel.isLoading = false
-            appStateManager.handleLoginResult(mockAuthData)
-        }
-    }
 }
 

--- a/BongBaek/BongBaek/Presentation/Login/View/RootView.swift
+++ b/BongBaek/BongBaek/Presentation/Login/View/RootView.swift
@@ -18,7 +18,7 @@ struct RootView: View {
                 LaunchView()
                     .onAppear {
                         DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
-                            appStateManager.moveToLogin()
+                            appStateManager.checkAuthStatus()
                         }
                     }
             case .login:
@@ -31,6 +31,12 @@ struct RootView: View {
             }
         }
         .animation(.easeInOut(duration: 0.3), value: appStateManager.currentState)
+        .sheet(isPresented: $appStateManager.showSignUpSheet) {
+            SignUpBottomSheetView {
+                print("hi")
+            }
+                .environmentObject(appStateManager)
+        }
 
     }
 }

--- a/BongBaek/BongBaek/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/BongBaek/BongBaek/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -19,6 +19,7 @@ class LoginViewModel: ObservableObject {
     
     private let authService: AuthServiceProtocol
     private var cancellables = Set<AnyCancellable>()
+    private let authManager = AuthManager.shared
     
     init(authService: AuthServiceProtocol = DIContainer.shared.authService) {
         self.authService = authService
@@ -86,20 +87,10 @@ class LoginViewModel: ObservableObject {
     }
     
    func loginwithKakao() {
-       if(UserApi.isKakaoTalkLoginAvailable()){
-           UserApi.shared.loginWithKakaoTalk{ oauthToken, error in
-               guard let oauthToken = oauthToken,
-                     error == nil else {return}
-               self.kakaologin(oauthToken:oauthToken)
-           }
-       } else {
-           UserApi.shared.loginWithKakaoAccount{ oauthToken, error in
-               guard let oauthToken = oauthToken,
-                     error == nil else {return}
-               self.kakaologin(oauthToken:oauthToken)
-           }
+       
+       Task {
+           await authManager.loginWithKakao()
        }
-        print("kakao로그인 성공")
     }
     
     func kakaologin(oauthToken:OAuthToken){

--- a/BongBaek/BongBaek/Presentation/Login/ViewModel/ProfileSettingViewModel.swift
+++ b/BongBaek/BongBaek/Presentation/Login/ViewModel/ProfileSettingViewModel.swift
@@ -1,0 +1,188 @@
+//
+//  ProfileSettingViewModel.swift
+//  BongBaek
+//
+//  Created by 임재현 on 7/14/25.
+//
+
+import Foundation
+import Combine
+import SwiftUI
+
+@MainActor
+class ProfileSettingViewModel: ObservableObject {
+    // MARK: - Published Properties
+    @Published var nickname: String = ""
+    @Published var selectedDate: String = ""
+    @Published var hasIncome: Bool = true
+    @Published var currentSelection: IncomeSelection = .none
+    
+    // UI State
+    @Published var isSigningUp: Bool = false
+    @Published var showErrorAlert: Bool = false
+    @Published var errorMessage: String = ""
+    @Published var navigateToMain: Bool = false
+    
+    // MARK: - Private Properties
+    private let authManager = AuthManager.shared
+    private var cancellables = Set<AnyCancellable>()
+    
+    // MARK: - Enums
+    enum IncomeSelection: Equatable {
+        case under200
+        case over200
+        case none
+        
+        var displayText: String {
+            switch self {
+            case .under200: return "월 200 이하"
+            case .over200: return "월 200 이상"
+            case .none: return ""
+            }
+        }
+        
+        var apiValue: String {
+            switch self {
+            case .under200: return "200만원 이하"
+            case .over200: return "200만원 이상"
+            case .none: return ""
+            }
+        }
+    }
+    
+    // MARK: - Computed Properties
+    var isStartButtonEnabled: Bool {
+        let basicFieldsValid = nickname.count >= 2 &&
+                              nickname.count <= 10 &&
+                              !selectedDate.isEmpty
+        
+        if hasIncome {
+            return basicFieldsValid && currentSelection != .none && !isSigningUp
+        } else {
+            return basicFieldsValid && !isSigningUp
+        }
+    }
+    
+    // MARK: - Initialization
+    init() {
+        setupAuthStateObserver()
+    }
+    
+    // MARK: - Public Methods
+    func selectIncome(_ selection: IncomeSelection) {
+        currentSelection = selection
+    }
+    
+    func toggleIncomeStatus() {
+        hasIncome.toggle()
+        if !hasIncome {
+            currentSelection = .none
+        }
+    }
+    
+    func performSignUp() {
+        guard isStartButtonEnabled else { return }
+        
+        isSigningUp = true
+        
+        let memberInfo = createMemberInfo()
+        print("회원가입 시작:", memberInfo)
+        
+        authManager.signUp(memberInfo: memberInfo)
+    }
+    
+    func dismissError() {
+        showErrorAlert = false
+        errorMessage = ""
+    }
+    
+    // MARK: - Private Methods
+    private func setupAuthStateObserver() {
+        authManager.$authState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] authState in
+                self?.handleAuthStateChange(authState)
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func handleAuthStateChange(_ authState: AuthManager.AuthState) {
+        switch authState {
+        case .authenticated:
+            // 회원가입 성공
+            isSigningUp = false
+            navigateToMain = true
+            print("회원가입 성공 - 메인으로 이동")
+            
+        case .needsSignUp:
+            // 회원가입 실패 ]
+            if isSigningUp { // 회원가입 진행 중이었다면 실패로 간주
+                isSigningUp = false
+                errorMessage = "회원가입에 실패했습니다. 다시 시도해주세요."
+                showErrorAlert = true
+                print("회원가입 실패")
+            }
+            
+        case .loading:
+            // 로딩 상태 유지
+            break
+            
+        case .needsLogin:
+            // 로그인이 필요한 상태로 변경됨 (예상치 못한 상황)
+            isSigningUp = false
+            errorMessage = "인증이 만료되었습니다. 다시 로그인해주세요."
+            showErrorAlert = true
+        }
+    }
+    
+    private func convertDateFormat(_ dateString: String) -> String {
+           let converted = dateString.replacingOccurrences(of: ".", with: "-")
+           print("날짜 형식 변환: \(dateString) → \(converted)")
+           return converted
+       }
+    
+    private func createMemberInfo() -> MemberInfo {
+        let kakaoId = getCurrentKakaoId()
+        
+        let incomeValue: String
+        if hasIncome {
+            incomeValue = currentSelection.apiValue
+        } else {
+            incomeValue = ""
+        }
+        let formattedBirthday = convertDateFormat(selectedDate)
+        return MemberInfo(
+            kakaoId: Int(kakaoId) ?? 0,
+            appleId: nil,
+            memberName: nickname,            
+            memberBirthday: formattedBirthday,
+            memberIncome: incomeValue
+        )
+    }
+    
+    private func getCurrentKakaoId() -> String {
+        // AuthManager에서 현재 로그인된 사용자의 kakaoId 가져오기
+        return authManager.getCurrentKakaoId()
+    }
+}
+
+extension ProfileSettingViewModel {
+    func isSelected(_ selection: IncomeSelection) -> Bool {
+        return currentSelection == selection
+    }
+    
+    func getSelectedIncomeText() -> String {
+        return currentSelection.displayText
+    }
+    
+    func logCurrentSelection() {
+        switch currentSelection {
+        case .under200:
+            print("선택된 수입: 월 200 이하")
+        case .over200:
+            print("선택된 수입: 월 200 이상")
+        case .none:
+            print("수입이 선택되지 않음")
+        }
+    }
+}


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->

토큰 관리 객체를 통한 로그인/회원가입 상태 옵저빙 및 화면 전환 로직 설계

## 🎫 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- ex item

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->

어떻게 하면 유저가 회원가입, 로그인을 했는지 확인하고 화면을 이동시키고 토큰을 관리할지 고민했습니다.
우선 보안을 고려하여, accessToken 과 refreshToken 은 KeyChain 으로 저장시켜주기위해, KeyCahin 의 CRUD 를 할수 있는 KeyChainManger 를 싱글톤 객체로 만들어주었습니다.


그리고,  토큰이 유효할 경우 바로 Main 화면으로 이동, 토큰이 있지만 유효하지 않거나 토큰이 없을 경우 로그인이 필요하므로, 이때의 각각의 상태에 따라 이벤트가 발생하면 해당 필요한 화면으로 이동시켜주는 AuthManger 를 만들어 각 상황에 따라 필요한 행동을 취할수 있도록 설계했습니다.

그리고 로그인을 통해 해당 유저가 신규유저일 경우 signUP 화면으로 이동하며 기존 회원일 경우 바로 mainTab 으로 이동할 수 있도록 로직을 설계해 주었습니다.


## 🎫 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   SE   |   13 mini   |   15 pro   |
| :-------------: | :----------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/4cd224cf-1166-431c-b379-2d7a47e55b3a" width ="250"> | <img src = "https://github.com/user-attachments/assets/05a47b71-ad2e-4742-a4e3-0e715a4c3679" width ="250"> | <img src = "" width ="250"> |

## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`AuthManager`
- 카카오 로그인을 통한 토큰을 얻는 과정에서, 실패할 경우 로그인이  필요하므로  authState = .needsLogin 를 통해 화면을 LoginView 로 이동시켜줍니다.
```swift
    func loginWithKakao() async {
        authState = .loading
        
        do {
            // 1. 카카오에서 토큰 획득
            let kakaoToken = try await kakaoLoginManager.login()
            print("카카오 로그인 성공, accessToken: \(kakaoToken)")
            
            // 2. 서버에 카카오 토큰 전송하여 앱 토큰 획득
            await loginWithKakaoToken(kakaoToken)
            
        } catch {
            print("카카오 로그인 실패: \(error)")
            authState = .needsLogin
        }
    }
    
        private func loginWithKakaoToken(_ kakaoToken: String) async {
        
        authService.login(accessToken: kakaoToken)
            .receive(on: DispatchQueue.main)
            .sink(
                receiveCompletion: { [weak self] completion in
                    if case .failure(let error) = completion {
                        print("서버 로그인 실패: \(error)")
                        self?.authState = .needsLogin
                    }
                },
                receiveValue: { [weak self] response in
                    print("response:123 \(response)")
                    self?.handleLoginResponse(response)
                }
            )
            .store(in: &cancellables)
    }
```

`KeychainManager`
- 키체인 매니저 객체를 통해 서버에서 받은 토큰들을 저장하고, 삭제하고, API 통신을 할때 사용할 수 있게 해주었습니다.
```swift
    /// 액세스 토큰과 리프레시 토큰을 동시에 저장
    func saveTokens(access: String, refresh: String) -> Result<Void, AuthError> {
        switch save(key: accessTokenKey, value: access) {
        case .success:
            switch save(key: refreshTokenKey, value: refresh) {
            case .success:
                return .success(())
            case .failure(let error):
                // 액세스 토큰 저장 성공했지만 리프레시 토큰 실패시 롤백
                delete(key: accessTokenKey)
                return .failure(error)
            }
        case .failure(let error):
            return .failure(error)
        }
    }


    /// 모든 토큰 삭제
    @discardableResult
    func clearTokens() -> Result<Void, AuthError> {
        let accessResult = delete(key: accessTokenKey)
        let refreshResult = delete(key: refreshTokenKey)
        
        // 둘 중 하나라도 실패하면 실패로 처리
        switch (accessResult, refreshResult) {
        case (.success, .success):
            return .success(())
        case (.failure(let error), _), (_, .failure(let error)):
            return .failure(error)
        }
    }
```


## ✅ Check List
- [v] Merge 대상 브랜치가 올바른가?
- [v] 최종 코드가 에러 없이 잘 동작하는가?
- [v] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #40 
