### PR TITLE
[feat] ScheduleModel 별로 View 클릭 시 각각의 AllRecords로 넘어가는 플로우 구현

### DIFF
--- a/BongBaek/BongBaek/Presentation/Home/Empty/EmptyCardView.swift
+++ b/BongBaek/BongBaek/Presentation/Home/Empty/EmptyCardView.swift
@@ -9,6 +9,17 @@ import SwiftUI
 
 struct EmptyCardView: View {
     @StateObject private var stepManager = GlobalStepManager()
+    
+    // 더미 데이터 생성
+    private let emptySchedule = ScheduleModel(
+        type: "새 일정",
+        relation: "",
+        name: "",
+        money: "0원",
+        location: "",
+        date: ""
+    )
+    
     var body: some View {
         VStack(spacing: 20) {
             VStack {
@@ -23,7 +34,7 @@ struct EmptyCardView: View {
                 .foregroundColor(.white)
                 //.padding(.top, 12)
                
-            NavigationLink(destination: AllRecordsView().environmentObject(stepManager)) {
+            NavigationLink(destination: AllRecordsView(scheduleData: emptySchedule).environmentObject(stepManager)) {
                 HStack(spacing: 4) {
                     Text("일정추가하기 >")
                         .captionRegular12()
@@ -46,4 +57,3 @@ struct EmptyCardView: View {
 #Preview {
     EmptyCardView()
 }
-

--- a/BongBaek/BongBaek/Presentation/Home/Schedule/ScheduleModel.swift
+++ b/BongBaek/BongBaek/Presentation/Home/Schedule/ScheduleModel.swift
@@ -24,5 +24,10 @@ let scheduleDummy: [ScheduleModel] = [
 ]
 
 
-let sDummy: [ScheduleModel] = []
+let sDummy: [ScheduleModel] = [
+    ScheduleModel(type: "생일", relation: "선후배", name: "임재현", money: "30,000원", location: "강남구 테헤란로 30 웨딩홀", date: "2027.10.01 (월)"),
+    ScheduleModel(type: "돌잔치", relation: "직장", name: "전지영", money: "100,000원", location: "중구 필동로1길 30", date: "2025.07.19 (토)"),
+    ScheduleModel(type: "생일", relation: "선후배", name: "임재현", money: "30,000원", location: "강남구 테헤란로 30 웨딩홀", date: "2027.10.01 (월)")
+
+]
 

--- a/BongBaek/BongBaek/Presentation/Home/Schedule/ScheduleView.swift
+++ b/BongBaek/BongBaek/Presentation/Home/Schedule/ScheduleView.swift
@@ -34,7 +34,10 @@ struct ScheduleView: View {
                 EmptyCardView()
             } else {
                 ForEach(schedules) { schedule in
-                    ScheduleCellView(schedule: schedule)
+                    NavigationLink(destination: AllRecordsView(scheduleData: schedule)) {
+                        ScheduleCellView(schedule: schedule)
+                    }
+                    .buttonStyle(PlainButtonStyle())
                 }
             }
         }
@@ -42,6 +45,7 @@ struct ScheduleView: View {
         .background(Color.black)
     }
 }
+
 #Preview {
     ScheduleView(schedules: scheduleDummy)
 }

--- a/BongBaek/BongBaek/Presentation/Record/View/AllRecordsView.swift
+++ b/BongBaek/BongBaek/Presentation/Record/View/AllRecordsView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct AllRecordsView: View {
+    let scheduleData: ScheduleModel
     @State private var isDetailExpanded = false
     @State private var memoText = ""
     @State private var keyboardHeight: CGFloat = 0
@@ -46,11 +47,11 @@ struct AllRecordsView: View {
                 
                 VStack(spacing: 12) {
                     VStack {
-                        Text("김승우의 결혼식")
+                        Text("\(scheduleData.name)의 \(scheduleData.type)")
                             .titleSemiBold16()
                             .foregroundStyle(.white)
                             
-                        Text("2024.08.10 (토)")
+                        Text(scheduleData.date)
                             .bodyRegular14()
                             .foregroundStyle(.gray300)
       
@@ -69,7 +70,7 @@ struct AllRecordsView: View {
                         
                         Spacer()
                         
-                        Text("50,000원")
+                        Text(scheduleData.money)
                             .titleSemiBold18()
                             .foregroundStyle(.white)
 
@@ -114,14 +115,15 @@ struct AllRecordsView: View {
                     
                     if isDetailExpanded {
                         VStack(alignment: .leading, spacing: 24) {
-                            DetailRow(image: "icon_person_16", title: "이름", value: "김봉백")
+                            DetailRow(image: "icon_person_16", title: "이름", value: scheduleData.name)
                             DetailRow(image: "icon_nickname_16", title: "별명", value: "봉봉")
-                            DetailRow(image: "icon_event_16", title: "관계", value: "가족/친척", valueTextColor: .blue, valueBackgroundColor: .blue.opacity(0.5))
+                            DetailRow(image: "icon_event_16", title: "관계", value: scheduleData.relation, valueTextColor: .blue, valueBackgroundColor: .blue.opacity(0.5))
                             
-                            DetailRow(image: "icon_event_16", title: "경조사", value: "결혼식", valueTextColor: .blue, valueBackgroundColor: .blue.opacity(0.5))
-                            DetailRow(image: "icon_event_16", title: "경조사비", value: "50,000원")
+                            DetailRow(image: "icon_event_16", title: "경조사", value: scheduleData.type, valueTextColor: .blue, valueBackgroundColor: .blue.opacity(0.5))
+                            DetailRow(image: "icon_event_16", title: "경조사비", value: scheduleData.money)
                             DetailRow(image: "icon_event_16", title: "참석여부", value: "참석", valueTextColor: .blue, valueBackgroundColor: .blue.opacity(0.5))
-                            DetailRow(image: "icon_event_16", title: "날짜", value: "Jun 10, 2024", valueTextColor: .blue, valueBackgroundColor: .blue.opacity(0.5))
+                            DetailRow(image: "icon_event_16", title: "날짜", value: scheduleData.date, valueTextColor: .blue, valueBackgroundColor: .blue.opacity(0.5))
+                            DetailRow(image: "icon_location_16", title: "장소", value: scheduleData.location)
                         }
                         .padding(20)
                         .background(.gray750)
@@ -228,5 +230,5 @@ struct DetailRow: View {
 }
 
 #Preview{
-    AllRecordsView()
+    AllRecordsView(scheduleData: scheduleDummy[0])
 }


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
- 생성된 ScheduleModel의 View들을 선택하면, 각각의 AllRecordsView로 넘어가는 플로우를 구현하였읍니다.

## 🎫 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- ex item

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->
- Model 값들이 각 View에 잘 매칭되어 문제 없도록 플로우 구현을 할 수 있을지에 대해 생각해봤습니다. 

## 🎫 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
| 구현 내용 | 13 mini |
|:--------:|:-------:|
| GIF | <img src="https://github.com/user-attachments/assets/20864c8f-d7d0-4bbc-935c-b58cf19564d6" width="250"> |

## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- 잘 구현한건지 모르겠읍니다... 리뷰 부탁드려요...😭

## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`ScheduleView`
- NavigationLink로 각 ScheduleCellView를 감싸서 클릭 가능하게 만들었습니다..
- destination에 AllRecordsView(scheduleData: schedule)로 선택된 스케줄 데이터를 문제없이 전달하도록 했슴다.
```swift
ForEach(schedules) { schedule in
    NavigationLink(destination: AllRecordsView(scheduleData: schedule)) {
        ScheduleCellView(schedule: schedule)
    }
    .buttonStyle(PlainButtonStyle())
}
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #45 
