### PR TITLE
Fix#50 Detail

### DIFF
--- a/BongBaek/BongBaek/Application/BongBaekApp.swift
+++ b/BongBaek/BongBaek/Application/BongBaekApp.swift
@@ -24,7 +24,7 @@ struct BongBaekApp: App {
     
     var body: some Scene {
         WindowGroup {
-            MainTabView()
+            RootView()
                 .onOpenURL(perform:{ url in
                     if(AuthApi.isKakaoTalkLoginUrl(url)){
                         _ = AuthController.handleOpenUrl(url:url)

--- a/BongBaek/BongBaek/Application/BongBaekApp.swift
+++ b/BongBaek/BongBaek/Application/BongBaekApp.swift
@@ -24,7 +24,7 @@ struct BongBaekApp: App {
     
     var body: some Scene {
         WindowGroup {
-            RootView()
+            MainTabView()
                 .onOpenURL(perform:{ url in
                     if(AuthApi.isKakaoTalkLoginUrl(url)){
                         _ = AuthController.handleOpenUrl(url:url)

--- a/BongBaek/BongBaek/Presentation/Home/FullSchedule/FullScheduleView.swift
+++ b/BongBaek/BongBaek/Presentation/Home/FullSchedule/FullScheduleView.swift
@@ -99,28 +99,34 @@ struct FullScheduleView: View {
                         }
                     }
 
-                    ForEach(filteredSchedulesGrouped.keys.sorted(by: <), id: \.self) { year in
-                        VStack(alignment: .leading, spacing: 16) {
-                            Text("\(year)년")
-                                .headBold24()
-                                .foregroundColor(.white)
+                    if filteredSchedulesGrouped.isEmpty{
+                        RecordsEmptyView(message: "참석한 경조사가 없습니다")
+                            .frame(maxWidth: .infinity, minHeight: 150)
+                            .padding(.top, 40)
+                    } else{
+                        ForEach(filteredSchedulesGrouped.keys.sorted(by: <), id: \.self) { year in
+                            VStack(alignment: .leading, spacing: 16) {
+                                Text("\(year)년")
+                                    .headBold24()
+                                    .foregroundColor(.white)
 
-                            let months = filteredSchedulesGrouped[year] ?? [:]
-                            ForEach(months.keys.sorted(), id: \.self) { month in
-                                VStack(alignment: .leading, spacing: 10) {
-                                    HStack(spacing: 12) {
-                                        Text("\(Int(month) ?? 0)월")
-                                            .titleSemiBold16()
-                                            .foregroundColor(.white)
-                                        
-                                        Rectangle()
-                                            .foregroundColor(.gray750)
-                                            .frame(height: 2)
-                                    }
-                                    .padding(.trailing, 20)
+                                let months = filteredSchedulesGrouped[year] ?? [:]
+                                ForEach(months.keys.sorted(), id: \.self) { month in
+                                    VStack(alignment: .leading, spacing: 10) {
+                                        HStack(spacing: 12) {
+                                            Text("\(Int(month) ?? 0)월")
+                                                .titleSemiBold16()
+                                                .foregroundColor(.white)
+                                            
+                                            Rectangle()
+                                                .foregroundColor(.gray750)
+                                                .frame(height: 2)
+                                        }
+                                        .padding(.trailing, 20)
 
-                                    ForEach(months[month] ?? []) { schedule in
-                                        FullScheduleCellView(model: schedule)
+                                        ForEach(months[month] ?? []) { schedule in
+                                            FullScheduleCellView(model: schedule)
+                                        }
                                     }
                                 }
                             }

--- a/BongBaek/BongBaek/Presentation/Home/FullSchedule/FullScheduleView.swift
+++ b/BongBaek/BongBaek/Presentation/Home/FullSchedule/FullScheduleView.swift
@@ -23,6 +23,17 @@ struct FullScheduleView: View {
     @State private var selectedTab: Tab = .home
     @Environment(\.dismiss) private var dismiss
     
+    var emptyMessage: String {
+            switch selectedCategory {
+            case .babyParty:
+                return "돌잔치가 없습니다"
+            case .wedding, .birthday, .funeral:
+                return "참석한 \(selectedCategory.displayName)이 없습니다"
+            case .all:
+                return "기록한 경조사가 없습니다. "
+            }
+        }
+    
     var schedulesGrouped: [String: [String: [ScheduleModel]]] {
         let grouped = Dictionary(grouping: scheduleDummy) { model in
             let components = model.date.split(separator: ".")

--- a/BongBaek/BongBaek/Presentation/Home/FullSchedule/FullScheduleView.swift
+++ b/BongBaek/BongBaek/Presentation/Home/FullSchedule/FullScheduleView.swift
@@ -111,7 +111,7 @@ struct FullScheduleView: View {
                     }
 
                     if filteredSchedulesGrouped.isEmpty{
-                        RecordsEmptyView(message: "참석한 경조사가 없습니다")
+                        RecordsEmptyView(message: emptyMessage)
                             .frame(maxWidth: .infinity, minHeight: 150)
                             .padding(.top, 40)
                     } else{

--- a/BongBaek/BongBaek/Presentation/Record/View/RecordView.swift
+++ b/BongBaek/BongBaek/Presentation/Record/View/RecordView.swift
@@ -127,6 +127,7 @@ struct RecordsHeaderView: View {
     @Binding var isDeleteMode: Bool
     @State private var showModifyView = false
     var onDeleteTapped: () -> Void = {}
+    @State private var showAlert = false
     
     var body: some View {
         HStack {
@@ -148,9 +149,12 @@ struct RecordsHeaderView: View {
 
                 Button(action: {
                     if isDeleteMode {
-                        onDeleteTapped() // ✅ 콜백 실행
+                        showAlert = true
+                        //onDeleteTapped() // ✅ 콜백 실행
+                    } else{
+                        isDeleteMode = true
                     }
-                    isDeleteMode.toggle()
+                    //isDeleteMode.toggle()
                 }) {
                     Image(systemName: isDeleteMode ? "checkmark" : "trash")
                         .font(.system(size: 18, weight: .medium))
@@ -158,6 +162,15 @@ struct RecordsHeaderView: View {
                 }
                 .frame(width: 44, height: 44)
                 .contentShape(Rectangle())
+                .alert("경조사 기록을 삭제하겠습니까?", isPresented: $showAlert) {
+                    Button("취소", role: .cancel) { }
+                    Button("삭제", role: .destructive) {
+                        onDeleteTapped()
+                        isDeleteMode = false
+                    }
+                } message: {
+                    Text("이 기록의 모든 내용이 삭제됩니다.")
+                }
             }
         }
         .padding(.horizontal, 20)

--- a/BongBaek/BongBaek/Presentation/Record/View/RecordView.swift
+++ b/BongBaek/BongBaek/Presentation/Record/View/RecordView.swift
@@ -170,6 +170,8 @@ struct RecordsHeaderView: View {
                     }
                 } message: {
                     Text("이 기록의 모든 내용이 삭제됩니다.")
+                        .bodyRegular14()
+                        .foregroundStyle(.gray600)
                 }
             }
         }

--- a/BongBaek/BongBaek/Presentation/Record/View/RecordView.swift
+++ b/BongBaek/BongBaek/Presentation/Record/View/RecordView.swift
@@ -23,6 +23,7 @@ struct RecordView: View {
     @State private var isDeleteMode = false
     @State private var selectedSection: RecordSection = .attended
     @State private var selectedCategory: EventsCategory = .all
+    @State private var selectedRecordID: Set<UUID> = []
 
     var attendedRecords: [ScheduleModel] {
 

--- a/BongBaek/BongBaek/Presentation/Record/View/RecordView.swift
+++ b/BongBaek/BongBaek/Presentation/Record/View/RecordView.swift
@@ -298,7 +298,7 @@ struct RecordCellView: View {
                     isSelected.toggle()
                 }) {
                     Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                        .foregroundColor(isSelected ? .red : .gray)
+                        .foregroundColor(isSelected ? .secondaryRed : .gray400)
                         .font(.system(size: 20))
                 }
                 .frame(width: 30)


### PR DESCRIPTION
## 🎫 What is the PR?
- 전반적인 UI Detail적인 부분을 진행했습니다 

## 🎫 Changes
- AlertMessage
- RecordsEmptyView % emptyMessage 설정
- 삭제할 Data ID값 저장

## 🎫 Thoughts
- 경조사별로 emptyMessage를 다르게 설정하였습니다
- alertMessage를 사용해봤습니다

## 🎫 Screenshot
|    구현 내용    |  
| :-------------: |
| GIF | <img src = "" width ="250"> | 
<img src = "https://github.com/user-attachments/assets/ef1b5653-395c-4c83-9ed6-2c885d87e1e9" width ="250"> |

## 🎫 To Reviewers
- 리드님이 요청하신 ID값 print와 alertmessage, UI 수정은 하였지만 삭제를 누를때 다시 reset되는 부분은 하지 못했습니다..! 감안해서 봐주시면 감사하겠습니다

## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`FullScheduleView` ,`RecordView`
- 처음부터 RecordsEmptyView, alert기능입니다. 
- emptyMessage는 상단에 switch,case로 각 case에 맞는 message를 나타내도록 했습니다. 
```swift

var emptyMessage: String {
            switch selectedCategory {
            case .babyParty:
                return "돌잔치가 없습니다"
            case .wedding, .birthday, .funeral:
                return "참석한 \(selectedCategory.displayName)이 없습니다"
            case .all:
                return "기록한 경조사가 없습니다. "
            }
        }

if filteredSchedulesGrouped.isEmpty{
                        RecordsEmptyView(message: emptyMessage)
                            .frame(maxWidth: .infinity, minHeight: 150)
                            .padding(.top, 40)

.alert("경조사 기록을 삭제하겠습니까?", isPresented: $showAlert) {
                    Button("취소", role: .cancel) { }
                    Button("삭제", role: .destructive) {
                        onDeleteTapped()
                        isDeleteMode = false
                    }
                } message: {
                    Text("이 기록의 모든 내용이 삭제됩니다.")
                        .bodyRegular14()
                        .foregroundStyle(.gray600)
                }
```

## ✅ Check List
- [v] Merge 대상 브랜치가 올바른가?
- [v] 최종 코드가 에러 없이 잘 동작하는가?
- [v] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #50 
