### PR TITLE
[Feat] 로그아웃 Flow 구현

### DIFF
--- a/BongBaek/BongBaek.xcodeproj/project.pbxproj
+++ b/BongBaek/BongBaek.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 		2C5D73512E2150320042F76E /* KakaoSDKTalk in Frameworks */ = {isa = PBXBuildFile; productRef = 2C5D73502E2150320042F76E /* KakaoSDKTalk */; };
 		2C5D73532E2150320042F76E /* KakaoSDKTemplate in Frameworks */ = {isa = PBXBuildFile; productRef = 2C5D73522E2150320042F76E /* KakaoSDKTemplate */; };
 		2C5D73552E2150320042F76E /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 2C5D73542E2150320042F76E /* KakaoSDKUser */; };
-		4632602F2E6727D5000A559A /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 4632602E2E6727D5000A559A /* FirebaseRemoteConfig */; };
+		469F3E402E6AC9980006A144 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 469F3E3F2E6AC9980006A144 /* FirebaseRemoteConfig */; };
 		46A237DA2E1CFFBF00CC2E90 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 46A237D92E1CFFBF00CC2E90 /* Lottie */; };
 		46C6943B2E1F712300FD6255 /* KakaoMapsSDK-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 46C6943A2E1F712300FD6255 /* KakaoMapsSDK-SPM */; };
 		46C6943E2E1F712E00FD6255 /* CombineMoya in Frameworks */ = {isa = PBXBuildFile; productRef = 46C6943D2E1F712E00FD6255 /* CombineMoya */; };
@@ -89,7 +89,7 @@
 				2C5D73512E2150320042F76E /* KakaoSDKTalk in Frameworks */,
 				46A237DA2E1CFFBF00CC2E90 /* Lottie in Frameworks */,
 				2C5D733F2E2150320042F76E /* KakaoSDK in Frameworks */,
-				4632602F2E6727D5000A559A /* FirebaseRemoteConfig in Frameworks */,
+				469F3E402E6AC9980006A144 /* FirebaseRemoteConfig in Frameworks */,
 				2C5D73552E2150320042F76E /* KakaoSDKUser in Frameworks */,
 				2C5D734D2E2150320042F76E /* KakaoSDKNavi in Frameworks */,
 				2C5D73532E2150320042F76E /* KakaoSDKTemplate in Frameworks */,
@@ -178,7 +178,7 @@
 				2C5D73502E2150320042F76E /* KakaoSDKTalk */,
 				2C5D73522E2150320042F76E /* KakaoSDKTemplate */,
 				2C5D73542E2150320042F76E /* KakaoSDKUser */,
-				4632602E2E6727D5000A559A /* FirebaseRemoteConfig */,
+				469F3E3F2E6AC9980006A144 /* FirebaseRemoteConfig */,
 			);
 			productName = BongBaek;
 			productReference = 46C48B5D2E1019DF008C1C90 /* BongBaek.app */;
@@ -267,7 +267,7 @@
 				46C694392E1F712300FD6255 /* XCRemoteSwiftPackageReference "KakaoMapsSDK-SPM" */,
 				46C6943C2E1F712E00FD6255 /* XCRemoteSwiftPackageReference "Moya" */,
 				2C5D733D2E2150320042F76E /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
-				4632602D2E6727D5000A559A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				469F3E3E2E6AC9980006A144 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 46C48B5E2E1019DF008C1C90 /* Products */;
@@ -662,7 +662,7 @@
 				minimumVersion = 2.24.5;
 			};
 		};
-		4632602D2E6727D5000A559A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+		469F3E3E2E6AC9980006A144 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
 			requirement = {
@@ -757,9 +757,9 @@
 			package = 2C5D733D2E2150320042F76E /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
 			productName = KakaoSDKUser;
 		};
-		4632602E2E6727D5000A559A /* FirebaseRemoteConfig */ = {
+		469F3E3F2E6AC9980006A144 /* FirebaseRemoteConfig */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 4632602D2E6727D5000A559A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			package = 469F3E3E2E6AC9980006A144 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseRemoteConfig;
 		};
 		46A237D92E1CFFBF00CC2E90 /* Lottie */ = {

--- a/BongBaek/BongBaek/Network/Base/AuthManager.swift
+++ b/BongBaek/BongBaek/Network/Base/AuthManager.swift
@@ -171,6 +171,23 @@ class AuthManager: ObservableObject {
     
     // MARK: - 로그아웃
     func logout() {
+        
+        authService.logout()
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        print("로그아웃 API 호출 실패: \(error)")
+                    } else {
+                        print("로그아웃 API 호출 성공")
+                    }
+                },
+                receiveValue: { response in
+                    print("로그아웃 응답: \(response)")
+                }
+            )
+            .store(in: &cancellables)
+        
+        // 로컬 토큰 정리
         let result = keychainManager.clearTokens()
         if case .failure(let error) = result {
             print("토큰 삭제 실패: \(error)")
@@ -238,6 +255,8 @@ class AuthManager: ObservableObject {
                     access: tokenInfo.accessToken,
                     refresh: tokenInfo.refreshToken
                 )
+                
+                print("token keyChain에 저장 성공!")
                 
                 if case .failure(let error) = saveResult {
                     print("임시 토큰 저장 실패: \(error)")

--- a/BongBaek/BongBaek/Network/Base/AuthTarget.swift
+++ b/BongBaek/BongBaek/Network/Base/AuthTarget.swift
@@ -69,21 +69,19 @@ extension AuthTarget: TargetType {
     }
     
     var headers: [String : String]? {
-        switch self {
-        case .kakaoLogin, .appleLogin, .logout:
-            return [
-                "Content-Type": "application/json"
-            ]
-        case .signUp(let memberInfo):
-            return [
-                "Content-Type": "application/json"
-            ]
-        case .retryToken:
-            let refreshToken = UserDefaults.standard.string(forKey: "refreshToken") ?? ""
-            return [
-                "Content-Type": "application/json",
-                "Authorization": "Bearer \(refreshToken)"
-            ]
+        // 기본 헤더
+        var headers = [
+            "Content-Type": "application/json"
+        ]
+        
+        // KeyChain에서 accessToken 가져오기
+        if let accessToken = KeychainManager.shared.accessToken {
+            headers["Authorization"] = "Bearer \(accessToken)"
+            print("Authorization 헤더 추가됨: Bearer \(accessToken.prefix(10))...")
+        } else {
+            print("AccessToken이 KeyChain에 없습니다")
         }
+        
+        return headers
     }
 }

--- a/BongBaek/BongBaek/Network/Base/AuthTarget.swift
+++ b/BongBaek/BongBaek/Network/Base/AuthTarget.swift
@@ -18,6 +18,7 @@ enum AuthTarget {
     case appleLogin(idToken: String)
     case signUp(memberInfo: MemberInfo)
     case retryToken
+    case logout
 }
 
 extension AuthTarget: TargetType {
@@ -38,12 +39,14 @@ extension AuthTarget: TargetType {
             "/api/v1/member/reissue"
         case .appleLogin:
             "/api/v1/oauth/apple"
+        case .logout:
+            "/api/v1/member/logout"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .kakaoLogin, .signUp,. retryToken, .appleLogin: .post
+        case .kakaoLogin, .signUp,. retryToken, .appleLogin, .logout: .post
         }
     }
     
@@ -56,7 +59,7 @@ extension AuthTarget: TargetType {
         case .signUp(let memberInfo):
             return .requestJSONEncodable(memberInfo)
             
-        case .retryToken:
+        case .retryToken, .logout:
             return .requestPlain
             
         case .appleLogin(let idToken):
@@ -67,7 +70,7 @@ extension AuthTarget: TargetType {
     
     var headers: [String : String]? {
         switch self {
-        case .kakaoLogin, .appleLogin:
+        case .kakaoLogin, .appleLogin, .logout:
             return [
                 "Content-Type": "application/json"
             ]

--- a/BongBaek/BongBaek/Network/Base/EventsTarget.swift
+++ b/BongBaek/BongBaek/Network/Base/EventsTarget.swift
@@ -23,7 +23,7 @@ enum EventsTarget {
 extension EventsTarget: TargetType {
     
     var baseURL: URL {
-        guard let url = URL(string: AppConfig.shared.baseURL) else {
+        guard let url = URL(string: EnvironmentSetting.baseURL) else {
             fatalError("Invalid base URL")
         }
         return url

--- a/BongBaek/BongBaek/Network/Model/Response/SignUpResponseData.swift
+++ b/BongBaek/BongBaek/Network/Model/Response/SignUpResponseData.swift
@@ -11,6 +11,7 @@ typealias SignUpResponse = BaseResponse<AuthData>
 typealias KaKaoLoginResponse = BaseResponse<AuthData>
 typealias AppleLoginResponse = BaseResponse<AppleAuthData>
 typealias RefreshTokenResponse = BaseResponse<TokenInfo>
+typealias LogoutResponse = BaseResponse<EmptyData>
 
 struct AuthData: Codable {
     let token: TokenInfo?

--- a/BongBaek/BongBaek/Network/Protocols/AuthServiceProtocol.swift
+++ b/BongBaek/BongBaek/Network/Protocols/AuthServiceProtocol.swift
@@ -13,4 +13,5 @@ protocol AuthServiceProtocol {
     func appleLogin(idToken: String) -> AnyPublisher<AppleLoginResponse, Error>
     func signUp(memberInfo: MemberInfo) -> AnyPublisher<SignUpResponse, Error>
     func retryToken() -> AnyPublisher<RefreshTokenResponse, Error>
+    func logout() -> AnyPublisher<LogoutResponse, Error>
 }

--- a/BongBaek/BongBaek/Network/Services/AuthService.swift
+++ b/BongBaek/BongBaek/Network/Services/AuthService.swift
@@ -42,5 +42,12 @@ class AuthService: AuthServiceProtocol {
             responseType: RefreshTokenResponse.self
         )
     }
+    
+    func logout() -> AnyPublisher<LogoutResponse, any Error> {
+        return networkService.request(
+            .logout,
+            responseType: LogoutResponse.self
+        )
+    }
 }
 

--- a/BongBaek/BongBaek/Presentation/MyPage/View/MyPageView.swift
+++ b/BongBaek/BongBaek/Presentation/MyPage/View/MyPageView.swift
@@ -131,7 +131,10 @@ struct MyPageView: View {
                         }
 
                         HStack {
-                            Button(action: {}) {
+                            Button(action: {
+                                AuthManager.shared.logout()
+//                                print("로그아웃 버튼 눌림")
+                            }) {
                                 Text("로그아웃")
                                     .foregroundColor(.gray400)
                                     .bodyRegular14()


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
- 로그아웃 API 연동을 통한 로그아웃 기능 구현 

## 🎫 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- AuthTarget
- AuthService

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->

- 로그아웃  response 성공 시 keyChainManager를 통해 token을 clear 해주고, navigationRouter 를 통해서 LoginView 화면으로 이동시켜 주었습니다.


## 🎫 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   13 mini   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/656f062a-efa7-4afd-9461-417b5e73114f" width ="250"> |
## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

단순 로그아웃 flow 확인용이므로 스크린샷은 13Mini 한개로 대체하였습니다.

## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`AuthManager`
- 로그아웃 응답은 성공/실패 값으로 오므로, 성공시 토큰 정리 및 로그인 화면으로 이동 flow 를 구현하였습니다.
```swift
    func logout() {
        
        authService.logout()
            .sink(
                receiveCompletion: { completion in
                    if case .failure(let error) = completion {
                        print("로그아웃 API 호출 실패: \(error)")
                    } else {
                        print("로그아웃 API 호출 성공")
                    }
                },
                receiveValue: { response in
                    print("로그아웃 응답: \(response)")
                }
            )
            .store(in: &cancellables)
        
        // 로컬 토큰 정리
        let result = keychainManager.clearTokens()
        if case .failure(let error) = result {
            print("토큰 삭제 실패: \(error)")
        }
        currentKakaoId = nil
        currentAppleId = nil
        loginType = nil  
        authState = .needsLogin
    }
```

## ✅ Check List
- [v] Merge 대상 브랜치가 올바른가?
- [v] 최종 코드가 에러 없이 잘 동작하는가?
- [v] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #98 
