### PR TITLE
[Test] LoginViewModel 개인정보처리방침 URL 관련 테스트 코드 작성 

### DIFF
--- a/BongBaek/BongBaek/Presentation/Login/View/LoginView.swift
+++ b/BongBaek/BongBaek/Presentation/Login/View/LoginView.swift
@@ -13,7 +13,7 @@ struct LoginView: View {
     @EnvironmentObject var appStateManager: AppStateManager
     @StateObject private var loginViewModel = LoginViewModel()
     @State private var test = false
-    @Environment(\.openURL) private var openURL
+//    @Environment(\.openURL) private var openURL
     
     
    var body: some View {
@@ -92,9 +92,7 @@ struct LoginView: View {
                                .foregroundStyle(.white)
                                .underline()
                                .onTapGesture {
-                                   if let url = URL(string: "https://www.notion.so/264f06bb0d3480d0b1eafa217b306105") {
-                                       openURL(url)
-                                   }
+                                   loginViewModel.openPrivacyPolicy()
                                }
 
                            Text("이용약관")
@@ -103,9 +101,7 @@ struct LoginView: View {
                                .underline()
                                .padding(.leading, 12)
                                .onTapGesture {
-                                   if let url = URL(string: "https://www.notion.so/bongtubaekseo/264f06bb0d348036b260f175a236ec7c") {
-                                       openURL(url)
-                                   }
+                                   loginViewModel.openTermsOfUse()
                                }
                        }
                        .padding(.leading, 50)

--- a/BongBaek/BongBaek/Presentation/Login/View/LoginView.swift
+++ b/BongBaek/BongBaek/Presentation/Login/View/LoginView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import _AuthenticationServices_SwiftUI
 
 struct LoginView: View {
     @State var isPresented = false
@@ -13,9 +14,7 @@ struct LoginView: View {
     @EnvironmentObject var appStateManager: AppStateManager
     @StateObject private var loginViewModel = LoginViewModel()
     @State private var test = false
-//    @Environment(\.openURL) private var openURL
-    
-    
+
    var body: some View {
        
        NavigationStack {
@@ -51,12 +50,8 @@ struct LoginView: View {
                            ProgressView().tint(.white) : nil
                        )
                        .overlay {
-                           loginViewModel.requestAppleOauth()
-                               .frame(maxWidth: 375)
-                               .frame(height: 44)
-                               .blendMode(.hue)
+                           appleLoginButton
                        }
-                       
                        
                        Button(action: {
                            appStateManager.loginWithKakao()
@@ -141,5 +136,33 @@ struct LoginView: View {
            .presentationDragIndicator(.visible)
        }
    }
+    
+    private var appleLoginButton: some View {
+        SignInWithAppleButton(
+            onRequest: { request in
+                request.requestedScopes = [.fullName, .email]
+                
+            },
+            onCompletion: { result in
+                switch result {
+                    
+                case .success(let authResults):
+                    if let appleIDCredential = authResults.credential as? ASAuthorizationAppleIDCredential {
+                        let identityToken = String(data: appleIDCredential.identityToken!, encoding: .utf8) ?? ""
+                        let authorizationCode = String(data: appleIDCredential.authorizationCode!, encoding: .utf8) ?? ""
+                        print("애플 인증 성공 - idToken: \(identityToken), authCode: \(authorizationCode)")
+                        loginViewModel.handleAppleLoginSuccess(identityToken: identityToken, authorizationCode: authorizationCode)
+                        
+                    }
+                case .failure(let error):
+                    print("error")
+                    loginViewModel.handleAppleLoginFailure(error: error)
+                }
+            }
+        )
+        .frame(maxWidth: 375)
+        .frame(height: 44)
+        .blendMode(.hue)
+    }
 }
 

--- a/BongBaek/BongBaek/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/BongBaek/BongBaek/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -25,8 +25,11 @@ class LoginViewModel: ObservableObject {
     private var authCode: String = ""
     private var idToken: String = ""
     
-    init(authService: AuthServiceProtocol = DIContainer.shared.authService) {
+    private let urlOpener: URLOpenProtocol
+    
+    init(authService: AuthServiceProtocol = DIContainer.shared.authService,urlOpener:URLOpenProtocol = URLOpener() ) {
         self.authService = authService
+        self.urlOpener = urlOpener
     }
     
     func signUp(memberInfo: MemberInfo) {
@@ -178,5 +181,18 @@ extension LoginViewModel {
                 }
             }
         )
+    }
+}
+
+extension LoginViewModel {
+    
+    func openPrivacyPolicy() {
+        guard let url = URL(string: PrivacyUrls.personalInformationURL.rawValue) else {return}
+        urlOpener.openLink(url: url)
+    }
+    
+    func openTermsOfUse() {
+        guard let url = URL(string: PrivacyUrls.termsOfUseURL.rawValue) else {return}
+        urlOpener.openLink(url: url)
     }
 }

--- a/BongBaek/BongBaek/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/BongBaek/BongBaek/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -141,46 +141,21 @@ class LoginViewModel: ObservableObject {
 
 extension LoginViewModel {
     // MARK: - apple oauth
-    func requestAppleOauth() -> SignInWithAppleButton {
-        return SignInWithAppleButton(
-            onRequest: { request in
-                request.requestedScopes = [.fullName, .email]
-            },
-            onCompletion: { [weak self] result in
-                
-                guard let self = self else {
-                    print("self가 nil입니다.")
-                    return
-                }
-                
-                switch result {
-                case .success(let authResults):
-                    switch authResults.credential {
-                    case let appleIDCredential as ASAuthorizationAppleIDCredential:
-                        let identityToken = String(data: appleIDCredential.identityToken!, encoding: .utf8) ?? ""
-                        let authorizationCode = String(data: appleIDCredential.authorizationCode!, encoding: .utf8) ?? ""
-                        
+    func handleAppleLoginSuccess(identityToken: String, authorizationCode: String) {
 
-                        print("애플 인증 성공 - idToken: \(identityToken), authCode: \(authorizationCode)")
-                        
-                        Task {
-                            await self.authManager.loginWithApple(idToken: identityToken)
-                        }
-
-                
-                         
-                        self.authCode = authorizationCode
-                        self.idToken = identityToken
-                        
-                    default:
-                        break
-                    }
-                case .failure(let error):
-                    print(error.localizedDescription)
-                    print("애플 인증 에러 - \(error)")
-                }
-            }
-        )
+        print("애플 인증 성공 - idToken: \(identityToken), authCode: \(authorizationCode)")
+        
+        self.authCode = authorizationCode
+        self.idToken = identityToken
+        
+        Task {
+            await authManager.loginWithApple(idToken: identityToken)
+        }
+    }
+    
+    func handleAppleLoginFailure(error: Error) {
+        isLoading = false
+        errorMessage = error.localizedDescription
     }
 }
 

--- a/BongBaek/BongBaek/Presentation/Login/ViewModel/PrivacyURLS.swift
+++ b/BongBaek/BongBaek/Presentation/Login/ViewModel/PrivacyURLS.swift
@@ -1,0 +1,28 @@
+//
+//  PrivacyURLS.swift
+//  BongBaek
+//
+//  Created by 임재현 on 9/26/25.
+//
+
+import Foundation
+import UIKit
+
+enum PrivacyUrls: String {
+    // 개인정보처리방침
+    case personalInformationURL = "https://www.notion.so/264f06bb0d3480d0b1eafa217b306105"
+    // 이용약관
+    case termsOfUseURL = "https://www.notion.so/bongtubaekseo/264f06bb0d348036b260f175a236ec7c"
+}
+
+
+
+protocol URLOpenProtocol {
+    func openLink(url: URL)
+}
+
+struct URLOpener: URLOpenProtocol {
+    func openLink(url: URL) {
+        UIApplication.shared.open(url)
+    }
+}

--- a/BongBaek/BongBaek/Presentation/Login/ViewModel/PrivacyURLS.swift
+++ b/BongBaek/BongBaek/Presentation/Login/ViewModel/PrivacyURLS.swift
@@ -26,3 +26,20 @@ struct URLOpener: URLOpenProtocol {
         UIApplication.shared.open(url)
     }
 }
+
+class MockURLOpener: URLOpenProtocol {
+    
+    var openLinkCalled: Bool = false
+    var lastOpenURL: URL?
+    
+     func openLink(url: URL) {
+        self.openLinkCalled = true
+        self.lastOpenURL = url
+    }
+    
+     func reset() {
+        self.openLinkCalled = false
+        self.lastOpenURL = nil
+
+     }
+}

--- a/BongBaek/BongBaekTests/LoginViewModelTests.swift
+++ b/BongBaek/BongBaekTests/LoginViewModelTests.swift
@@ -54,6 +54,24 @@ final class LoginViewModelTests: XCTestCase {
         XCTAssertNotNil(url, "이용약관 URL이 올바르게 생성되지 않았습니다.")
         XCTAssertTrue(isValidURL(url: urlString), "이용약관 URL은 올바른 포맷이어야합니다.")
     }
+    
+    
+    // URLOpenr 가 주입이 제대로 되었는지 검증하는 함수
+    @MainActor
+    func testURLOpener_isInjectedWithDefaultValue() async {
+        //Given
+        let mockOpener = MockURLOpener()
+        let viewModel = LoginViewModel(urlOpener: mockOpener)
+        
+        //When
+        viewModel.openPrivacyPolicy()
+        
+        //Then
+        XCTAssertTrue(mockOpener.openLinkCalled, "openURL 이 호출되었는가")
+        XCTAssertEqual(mockOpener.lastOpenURL?.absoluteString,
+                       PrivacyUrls.personalInformationURL.rawValue,
+                       "openURL 이 올바른지 검증")
+    }
 }
 
 extension LoginViewModelTests {

--- a/BongBaek/BongBaekTests/LoginViewModelTests.swift
+++ b/BongBaek/BongBaekTests/LoginViewModelTests.swift
@@ -10,22 +10,22 @@ import XCTest
 
 final class LoginViewModelTests: XCTestCase {
     
-    var viewModel: LoginViewModel!
+    var sut: LoginViewModel!
     
     override func setUp() async throws {
-        viewModel = await LoginViewModel()
+        sut = await LoginViewModel()
     }
     
     override func tearDown() {
-        viewModel = nil
+        sut = nil
     }
     
     func testViewModelSuccessfullyInitialization() async {
-        XCTAssertNotNil(viewModel, "viewModel이 초기화가 되어서 메세지가 뜨면 안됨")
+        XCTAssertNotNil(sut, "viewModel이 초기화가 되어서 메세지가 뜨면 안됨")
     }
     
     func testViewModelFailedInitialization() async {
-        XCTAssertNil(viewModel, "viewModel이 초기화가 되었는가?- 이 테스트 실패하면 viewModel 초기화 된것")
+        XCTAssertNil(sut, "viewModel이 초기화가 되었는가?- 이 테스트 실패하면 viewModel 초기화 된것")
     }
     
     /// 개인정보처리방침 URL 값이 올바른 값인지 검증하는 함수

--- a/BongBaek/BongBaekTests/LoginViewModelTests.swift
+++ b/BongBaek/BongBaekTests/LoginViewModelTests.swift
@@ -1,0 +1,30 @@
+//
+//  LoginViewModelTests.swift
+//  BongBaekTests
+//
+//  Created by 임재현 on 9/26/25.
+//
+
+import XCTest
+@testable import BongBaek
+
+final class LoginViewModelTests: XCTestCase {
+    
+    var viewModel: LoginViewModel!
+    
+    override func setUp() async throws {
+        viewModel = await LoginViewModel()
+    }
+    
+    override func tearDown() {
+        viewModel = nil
+    }
+    
+    func testViewModelSuccessfullyInitialization() async {
+        XCTAssertNotNil(viewModel, "viewModel이 초기화가 되어서 메세지가 뜨면 안됨")
+    }
+    
+    func testViewModelFailedInitialization() async {
+        XCTAssertNil(viewModel, "viewModel이 초기화가 되었는가?- 이 테스트 실패하면 viewModel 초기화 된것")
+    }
+}

--- a/BongBaek/BongBaekTests/LoginViewModelTests.swift
+++ b/BongBaek/BongBaekTests/LoginViewModelTests.swift
@@ -27,4 +27,39 @@ final class LoginViewModelTests: XCTestCase {
     func testViewModelFailedInitialization() async {
         XCTAssertNil(viewModel, "viewModel이 초기화가 되었는가?- 이 테스트 실패하면 viewModel 초기화 된것")
     }
+    
+    /// 개인정보처리방침 URL 값이 올바른 값인지 검증하는 함수
+    func testPersonaInformationURL_ShouldReturnValidURL() {
+        //Given
+        let urlString = PrivacyUrls.personalInformationURL.rawValue
+        
+        //When
+        let url = URL(string: urlString)
+        
+        //Then
+        XCTAssertNotNil(url, "개인정보처리방침 URL이 올바르게 생성되지 않았습니다.")
+        XCTAssertTrue(isValidURL(url: urlString), "개인정보처리방침 URL은 올바른 포맷이어야합니다.")
+    }
+    
+    /// 이용약관 URL 값이 올바른 값인지 검증하는 함수
+    
+    func testTermsOfUseURL_ShouldReturnValidURL() {
+        //Given
+        let urlString = PrivacyUrls.termsOfUseURL.rawValue
+        
+        //When
+        let url = URL(string: urlString)
+        
+        //Then
+        XCTAssertNotNil(url, "이용약관 URL이 올바르게 생성되지 않았습니다.")
+        XCTAssertTrue(isValidURL(url: urlString), "이용약관 URL은 올바른 포맷이어야합니다.")
+    }
+}
+
+extension LoginViewModelTests {
+    func isValidURL(url: String) -> Bool {
+        guard let url = URL(string: url) else {return false}
+        
+        return url.scheme?.lowercased() == "https" && url.host(percentEncoded: false) != nil
+    }
 }


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
- LoginViewModel 에서 개인정보처리방침, 이용약관 버튼 로직에 관련 TestCode 작성

## 🎫 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
### 리팩토링
- **URL 열기 로직 분리**: `openURL` (SwiftUI) → `UIApplication.shared.open()` (UIKit)
- **관심사 분리**: View의 URL 로직을 ViewModel로 이동
- **테스트 가능성 향상**: URLOpener 프로토콜 도입으로 의존성 주입 가능

### 테스트 추가
- LoginViewModel 초기화 검증
- URL 유효성 검증 (개인정보처리방침, 이용약관)
- URL 열기 기능 동작 검증

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->

- 우선 테스트 코드 작성에 앞서 코드 리팩토링이 필요했습니다. 기존에는 LoginView 에서 `openURL` 을 사용하여, 해당 로직을 테스트 하기 위해서는 View 와 ViewModel 의 분리가 필요했습니다. 그 과정에서 openURL 은 View 에서만 사용이 가능한 문제를 발견했고, UIKit 에서 url 을 이동하는 방식인 `UIApplication.shared.open()` 방식으로 코드를 변경했습니다.

- 그 이후 LoginViewModel이 제대로 초기화 되는지 검증하는 TestCase를 작성했습니다.

- 해당 테스트 통과 이후 개인정보처리방침, 이용약관 버튼이 눌렸을때 작동에 대한 TestCase를 수립하고 검증하는 코드를 작성했습니다. 

- URL 이 올바르게 작동하는 방식 검증 단계에서, 의존성 주입을 통해 MockURLOpener 객체를 만들어서 프로덕션 코드와 테스트 코드를 분리시켜, 테스트 단계에서 url 에 직접 들어가서 확인하지 않을 수 있도록 설계해주었습니다.
 


## 🧪 테스트 케이스

### 1️⃣ ViewModel 초기화 검증
**목적**: LoginViewModel이 정상적으로 초기화되는지 확인
```swift
func testViewModelSuccessfullyInitialization() async {
    XCTAssertNotNil(sut, "viewModel이 초기화가 되어서 메세지가 뜨면 안됨")
}
```
**목적**: LoginViewModel이 정상적으로 초기화되는지 확인 (해당 함수는 실패해야함)
```swift
func testViewModelSuccessfullyInitialization() async {
    XCTAssertNotNil(sut, "viewModel이 초기화가 되어서 메세지가 뜨면 안됨")
}
```

### 2️⃣ URL 유효성 검증 (개인정보처리방침, 이용약관)

**목적**: 하드코딩된 URL들이 올바른 형식인지 확인
```swift
func testPersonaInformationURL_ShouldReturnValidURL() {
    //Given
    let urlString = PrivacyUrls.personalInformationURL.rawValue
    
    //When
    let url = URL(string: urlString)
    
    //Then
    XCTAssertNotNil(url, "개인정보처리방침 URL이 올바르게 생성되지 않았습니다.")
    XCTAssertTrue(isValidURL(url: urlString), "개인정보처리방침 URL은 올바른 포맷이어야합니다.")
}

func isValidURL(url: String) -> Bool {
    guard let url = URL(string: url) else { return false }
    
    return url.scheme?.lowercased() == "https" && url.host(percentEncoded: false) != nil
}
```

### 3️⃣ URL 열기 기능 동작 검증

**목적**:  개인정보처리방침 버튼 클릭 시 올바른 URL로 열기 함수가 호출되는지 확인
```swift
@MainActor
func testURLOpener_isInjectedWithDefaultValue() async {
    //Given
    let mockOpener = MockURLOpener()
    let viewModel = LoginViewModel(urlOpener: mockOpener)
    
    //When
    viewModel.openPrivacyPolicy()
    
    //Then
    XCTAssertTrue(mockOpener.openLinkCalled, "openURL 이 호출되었는가")
    XCTAssertEqual(mockOpener.lastOpenURL?.absoluteString,
                   PrivacyUrls.personalInformationURL.rawValue,
                   "openURL 이 올바른지 검증")
}
```


## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`LoginViewModel`
- LoginViewModel 에서 URLOpenProtocol 타입의 URLOpener 를 주입 받을 수 있도록 해주었습니다.
```swift

class LoginViewModel: ObservableObject {

    private let authService: AuthServiceProtocol

    init(authService: AuthServiceProtocol = DIContainer.shared.authService,urlOpener:URLOpenProtocol = URLOpener() ) {
        self.authService = authService
        self.urlOpener = urlOpener
    }
}
```

그 이후,  같은 URLOpenProtocol 를 채택한 MockURLOpener 객체를 생성해주어, 테스트시 갈아 끼울 수 있는 객체를 생성해주었고,

`MockURLOpener`
```swift
class MockURLOpener: URLOpenProtocol {
    
    var openLinkCalled: Bool = false
    var lastOpenURL: URL?
    
    func openLink(url: URL) {
        self.openLinkCalled = true
        self.lastOpenURL = url
    }
    
    func reset() {
        self.openLinkCalled = false
        self.lastOpenURL = nil
    }
}
```

해당 코드에서는,  함수가 호출되었는지 확인할 수 있도록 openLinkCalled 플래그 값과, 호출한 URL 값을 확인할 수 있는 lastOpenURL 값을 선언해주었습니다.

이를통해 직접 url 에접근하지 않고도 해당 url 호출 주소와, 제대로 동작을 하는지 확인하는 테스트코드를 작성 할 수 있었습니다.

## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

이후에 애플로그인, 카카오 로그인과 회원가입 에 대한 TestCode 작성 예정입니다. 길어질 것 같아서 세분화 해서 PR 올리겠습니다.

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #
