### PR TITLE
[Feat] LoginFlow 다크/라이트 모드 색상 지정 적용

### DIFF
--- a/BongBaek/BongBaek/Global/Components/CheckButton.swift
+++ b/BongBaek/BongBaek/Global/Components/CheckButton.swift
@@ -39,11 +39,12 @@ struct CheckButton: View {
         HStack(spacing: 12) {
             ZStack {
                 RoundedRectangle(cornerRadius: 4)
-                    .stroke(isChecked ? Color.primaryNormal : Color.gray.opacity(0.5), lineWidth: 1.5)
+                    .stroke(.borderFieldDefault, lineWidth: 1.5)
                     .frame(width: 20, height: 20)
                     .background(
                         RoundedRectangle(cornerRadius: 4)
-                            .fill(isChecked ? Color.primaryNormal : Color.clear)
+//                            .fill(.bgStatusFocused)
+                            .fill(isChecked ? .bgStatusFocused : Color.clear)
                     )
                 
                 if isChecked {
@@ -61,11 +62,11 @@ struct CheckButton: View {
                         if isRequired {
                             Text("[필수]")
                                 .bodyRegular16()
-                                .foregroundColor(.gray300)
+                                .foregroundColor(.txtDisplayTierary)
                         } else {
                             Text("[선택]")
                                 .bodyRegular16()
-                                .foregroundColor(.gray300)
+                                .foregroundColor(.txtDisplayTierary)
                         }
                     }
                     
@@ -73,11 +74,11 @@ struct CheckButton: View {
                     if isHighlighted {
                         Text(title)
                             .titleSemiBold16()
-                            .foregroundColor(.white)
+                            .foregroundColor(.txtDisplaySecondary)
                     } else {
                         Text(title)
                             .bodyRegular16()
-                            .foregroundColor(.gray300)
+                            .foregroundColor(.txtDisplayTierary)
                     }
                 }
                 
@@ -89,7 +90,7 @@ struct CheckButton: View {
                     } label: {
                         Image(systemName: "chevron.right")
                             .font(.system(size: 18, weight: .medium))
-                            .foregroundColor(.gray300)
+                           // .foregroundColor(.int)
                     }
                 }
             }

--- a/BongBaek/BongBaek/Global/Components/CheckButton.swift
+++ b/BongBaek/BongBaek/Global/Components/CheckButton.swift
@@ -43,14 +43,13 @@ struct CheckButton: View {
                     .frame(width: 20, height: 20)
                     .background(
                         RoundedRectangle(cornerRadius: 4)
-//                            .fill(.bgStatusFocused)
                             .fill(isChecked ? .bgStatusFocused : Color.clear)
                     )
                 
                 if isChecked {
                     Image(systemName: "checkmark")
                         .font(.system(size: 12, weight: .bold))
-                        .foregroundColor(.gray750)
+                        .foregroundColor(.bgDisplayCard)
                         .scaleEffect(isChecked ? 1.0 : 0.5)
                         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isChecked)
                 }
@@ -90,7 +89,7 @@ struct CheckButton: View {
                     } label: {
                         Image(systemName: "chevron.right")
                             .font(.system(size: 18, weight: .medium))
-                           // .foregroundColor(.int)
+                            .foregroundColor(.iconInteractiveDefault)
                     }
                 }
             }

--- a/BongBaek/BongBaek/Global/Components/TabView/CustomTabView.swift
+++ b/BongBaek/BongBaek/Global/Components/TabView/CustomTabView.swift
@@ -34,7 +34,7 @@ struct CustomTabView: View {
             )
             
             TabBarItem(
-                tab: .content,
+                tab: .contents,
                 selectedTab: $selectedTab,
                 imageName: "icon=icon_contents, status=off",
                 title: "콘텐츠"

--- a/BongBaek/BongBaek/Global/Components/TabView/Tab.swift
+++ b/BongBaek/BongBaek/Global/Components/TabView/Tab.swift
@@ -11,6 +11,6 @@ enum Tab {
     case home
     case recommend
     case record
-    case content
+    case contents
     case setting
 }

--- a/BongBaek/BongBaek/Global/Components/TextField/CustomTextField.swift
+++ b/BongBaek/BongBaek/Global/Components/TextField/CustomTextField.swift
@@ -68,7 +68,7 @@ struct CustomTextField: View {
                     .resizable()
                     .renderingMode(.template)
                     .frame(width: 20,height: 20)
-                    .foregroundColor(.gray400)
+                    .foregroundColor(.iconFocusedPrimary)
                 
                 HStack(spacing: 2) {
                     
@@ -79,7 +79,7 @@ struct CustomTextField: View {
                     } else {
                         Text(title)
                             .bodyMedium16()
-                            .foregroundColor(isRecommendationEdit ? .gray400 : .white)
+                            .foregroundColor(isRecommendationEdit ? .gray400 : .txtDisplaySecondary)
                     }
 
                     
@@ -88,7 +88,7 @@ struct CustomTextField: View {
                         VStack {
                             Text("*")
                                 .bodyMedium16()
-                                .foregroundColor(.primaryNormal)
+                                .foregroundColor(.txtStatusFocused)
                                 .padding(.top, 4)
                                 .padding(.leading, 1)
                             
@@ -114,7 +114,7 @@ struct CustomTextField: View {
                             if displayText.isEmpty {
                                 Text(placeholder)
                                     .font(.system(size: 16))
-                                    .foregroundColor(.gray.opacity(0.6))
+                                    .foregroundColor(.txtFieldPlaceholder)
                             }
                             
                             TextField("", text: $displayText)

--- a/BongBaek/BongBaek/Global/Components/TextField/CustomTextField.swift
+++ b/BongBaek/BongBaek/Global/Components/TextField/CustomTextField.swift
@@ -122,8 +122,8 @@ struct CustomTextField: View {
                                 .textFieldStyle(PlainTextFieldStyle())
                                 .focused($isFocused)
                                 .disabled(isReadOnly)
-                                .foregroundColor(isRecommendationEdit ? .gray400 : .gray100)
-                                .tint(.white)
+                                .foregroundColor(isRecommendationEdit ? .gray400 : .txtFieldValue)
+                                .tint(.txtFieldValue)
                                 .keyboardType(keyboardType) // 키보드 타입 적용
                                 .onChange(of: displayText) { _, newValue in
                                     handleTextChange(newValue)
@@ -333,18 +333,18 @@ enum ValidationState {
     func color(isReadOnly: Bool = false, isRecommendationEdit: Bool = false) -> Color {
         switch self {
         case .normal:
-            return .gray500
+            return .borderFieldDefault
         case .valid:
-            return .primaryNormal
+            return .borderStatusFocused
         case .invalid:
-            return .secondaryRed
+            return .borderStatusError
         case .focused:
-            return .primaryNormal
+            return .borderStatusFocused
         case .completed:
             if isReadOnly && isRecommendationEdit {
                 return .lineNormal
             } else {
-                return .white
+                return .borderFieldFilled
             }
         }
     }

--- a/BongBaek/BongBaek/Global/NavigationPathManager.swift
+++ b/BongBaek/BongBaek/Global/NavigationPathManager.swift
@@ -29,7 +29,7 @@ enum RecommendRoute: Hashable {
     case MyPageView
     case ModifyView(profileData: UpdateProfileData?)
     case profileSettingView
-    case contentView
+    case contentsView
     case contentDetailView
     
     var displayName: String {
@@ -59,7 +59,7 @@ enum RecommendRoute: Hashable {
         case .MyPageView : return "MyPageView"
             
         case .profileSettingView: return "profileSettingView"
-        case .contentView:  return "contentView"
+        case .contentsView:  return "contentsView"
             
         case .contentDetailView: return "contentDetailView"
             

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_disabled_primary.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_disabled_primary.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.588",
-          "green" : "0.580",
-          "red" : "0.576"
+          "blue" : "0.686",
+          "green" : "0.675",
+          "red" : "0.671"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.455",
-          "green" : "0.451",
-          "red" : "0.443"
+          "blue" : "0.318",
+          "green" : "0.314",
+          "red" : "0.306"
         }
       },
       "idiom" : "universal"

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_disabled_primary.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_disabled_primary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.588",
+          "green" : "0.580",
+          "red" : "0.576"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.455",
+          "green" : "0.451",
+          "red" : "0.443"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_disabled_secondary.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_disabled_secondary.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "0.498",
-          "red" : "0.384"
+          "blue" : "0.784",
+          "green" : "0.773",
+          "red" : "0.769"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.984",
-          "green" : "0.863",
-          "red" : "0.875"
+          "blue" : "0.455",
+          "green" : "0.451",
+          "red" : "0.443"
         }
       },
       "idiom" : "universal"

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_disabled_secondary.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_disabled_secondary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.498",
+          "red" : "0.384"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.984",
+          "green" : "0.863",
+          "red" : "0.875"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_focused_primary.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_focused_primary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_focused_primary.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_focused_primary.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.000",
-          "green" : "0.000",
-          "red" : "0.000"
+          "blue" : "1.000",
+          "green" : "0.498",
+          "red" : "0.431"
         }
       },
       "idiom" : "universal"
@@ -24,8 +24,8 @@
         "components" : {
           "alpha" : "1.000",
           "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
+          "green" : "0.498",
+          "red" : "0.431"
         }
       },
       "idiom" : "universal"

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_focused_secondary.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_focused_secondary.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.098",
-          "green" : "0.094",
-          "red" : "0.094"
+          "blue" : "1.000",
+          "green" : "0.718",
+          "red" : "0.682"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.859",
-          "green" : "0.859",
-          "red" : "0.855"
+          "blue" : "1.000",
+          "green" : "0.718",
+          "red" : "0.682"
         }
       },
       "idiom" : "universal"

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_focused_secondary.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_focused_secondary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.098",
+          "green" : "0.094",
+          "red" : "0.094"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.859",
+          "green" : "0.859",
+          "red" : "0.855"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_interactive_default.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_interactive_default.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.588",
+          "green" : "0.580",
+          "red" : "0.576"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.455",
+          "green" : "0.451",
+          "red" : "0.443"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_interactive_default.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_interactive_default.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.455",
-          "green" : "0.451",
-          "red" : "0.443"
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_interactive_inverse.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_interactive_inverse.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.098",
-          "green" : "0.094",
-          "red" : "0.094"
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.859",
-          "green" : "0.859",
-          "red" : "0.855"
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_interactive_knob.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_interactive_knob.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.098",
+          "green" : "0.094",
+          "red" : "0.094"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.859",
+          "green" : "0.859",
+          "red" : "0.855"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_selected_menu.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_selected_menu.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_selected_menu.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_selected_menu.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.000",
-          "green" : "0.000",
-          "red" : "0.000"
+          "blue" : "0.294",
+          "green" : "0.290",
+          "red" : "0.286"
         }
       },
       "idiom" : "universal"

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_status_error.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_status_error.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "0.498",
-          "red" : "0.384"
+          "blue" : "0.490",
+          "green" : "0.427",
+          "red" : "0.918"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.984",
-          "green" : "0.863",
-          "red" : "0.875"
+          "blue" : "0.655",
+          "green" : "0.604",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_status_error.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/IconColor/icon_status_error.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.498",
+          "red" : "0.384"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.984",
+          "green" : "0.863",
+          "red" : "0.875"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/background/bg_display_primary.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/background/bg_display_primary.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.000",
-          "green" : "0.000",
-          "red" : "0.000"
+          "blue" : "0.086",
+          "green" : "0.082",
+          "red" : "0.078"
         }
       },
       "idiom" : "universal"

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/border/border_interactive_switch.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/border/border_interactive_switch.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.941",
-          "green" : "0.929",
-          "red" : "0.922"
+          "blue" : "0.859",
+          "green" : "0.859",
+          "red" : "0.855"
         }
       },
       "idiom" : "universal"

--- a/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/text/txt_display_subtle.colorset/Contents.json
+++ b/BongBaek/BongBaek/Global/Resources/Assets.xcassets/Colors/text/txt_display_subtle.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "0.718",
-          "red" : "0.682"
+          "blue" : "0.984",
+          "green" : "0.863",
+          "red" : "0.875"
         }
       },
       "idiom" : "universal"

--- a/BongBaek/BongBaek/Presentation/ContentsView.swift
+++ b/BongBaek/BongBaek/Presentation/ContentsView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct ContentView: View {
+struct ContentsView: View {
     @EnvironmentObject var router: NavigationRouter
     @StateObject private var viewModel = ContentViewModel()
     @State private var selectedCategory: ScheduleCategory = .all

--- a/BongBaek/BongBaek/Presentation/Home/MainTabView.swift
+++ b/BongBaek/BongBaek/Presentation/Home/MainTabView.swift
@@ -42,8 +42,8 @@ struct MainTabView: View {
                                          }
                                      }
                                  }
-                        case .content:
-                            ContentView()
+                        case .contents:
+                            ContentsView()
                                 .environmentObject(router)
                         case .setting:
                             MyPageView()
@@ -196,8 +196,8 @@ struct MainTabView: View {
         case .profileSettingView:
             ProfileSettingView()
                 .environmentObject(router)
-        case .contentView:
-            ContentView()
+        case .contentsView:
+            ContentsView()
                 .environmentObject(router)
             
         case .contentDetailView:

--- a/BongBaek/BongBaek/Presentation/Login/View/DatePickerBottomSheetView.swift
+++ b/BongBaek/BongBaek/Presentation/Login/View/DatePickerBottomSheetView.swift
@@ -76,7 +76,7 @@ struct DatePickerBottomSheetView: View {
             .datePickerStyle(.wheel)
             .labelsHidden()
             .environment(\.locale, Locale(identifier: "ko_KR"))
-            .preferredColorScheme(.dark)
+//            .preferredColorScheme(.dark)
             .accentColor(.blue)
             .padding(.horizontal, 20)
             
@@ -90,16 +90,16 @@ struct DatePickerBottomSheetView: View {
             } label: {
                 Text("선택완료")
                     .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(.white)
+                    .foregroundColor(.txtInteractiveInverse)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 16)
-                    .background(.primaryNormal)
+                    .background(.bgStatusFocused)
                     .cornerRadius(12)
             }
             .padding(.horizontal, 20)
             .padding(.bottom, 20)
         }
-        .background(.gray750)
+        .background(.bgDisplayCard)
         .onAppear {
             setInitialDate()
         }

--- a/BongBaek/BongBaek/Presentation/Login/View/LoginView.swift
+++ b/BongBaek/BongBaek/Presentation/Login/View/LoginView.swift
@@ -79,12 +79,12 @@ struct LoginView: View {
                    VStack(alignment: .leading,spacing: 0) {
                        Text("로그인하시면 아래 내용에 동의하는 것으로 간주됩니다.")
                            .captionRegular12()
-                           .foregroundStyle(.txtDisplaySecondary)
+                           .foregroundStyle(.txtDisplayTierary)
 
                        HStack {
                            Text("개인정보 처리방침")
                                .captionRegular12()
-                               .foregroundStyle(.txtInteractiveSecondary)
+                               .foregroundStyle(.txtInteractiveInverse)
                                .underline()
                                .onTapGesture {
                                    loginViewModel.openPrivacyPolicy()
@@ -92,7 +92,7 @@ struct LoginView: View {
 
                            Text("이용약관")
                                .captionRegular12()
-                               .foregroundStyle(.txtInteractiveSecondary)
+                               .foregroundStyle(.txtInteractiveInverse)
                                .underline()
                                .padding(.leading, 12)
                                .onTapGesture {

--- a/BongBaek/BongBaek/Presentation/Login/View/LoginView.swift
+++ b/BongBaek/BongBaek/Presentation/Login/View/LoginView.swift
@@ -79,12 +79,12 @@ struct LoginView: View {
                    VStack(alignment: .leading,spacing: 0) {
                        Text("로그인하시면 아래 내용에 동의하는 것으로 간주됩니다.")
                            .captionRegular12()
-                           .foregroundStyle(.white)
+                           .foregroundStyle(.txtDisplaySecondary)
 
                        HStack {
                            Text("개인정보 처리방침")
                                .captionRegular12()
-                               .foregroundStyle(.white)
+                               .foregroundStyle(.txtInteractiveSecondary)
                                .underline()
                                .onTapGesture {
                                    loginViewModel.openPrivacyPolicy()
@@ -92,7 +92,7 @@ struct LoginView: View {
 
                            Text("이용약관")
                                .captionRegular12()
-                               .foregroundStyle(.white)
+                               .foregroundStyle(.txtInteractiveSecondary)
                                .underline()
                                .padding(.leading, 12)
                                .onTapGesture {

--- a/BongBaek/BongBaek/Presentation/Login/View/ProfileSettingView.swift
+++ b/BongBaek/BongBaek/Presentation/Login/View/ProfileSettingView.swift
@@ -27,9 +27,9 @@ struct ProfileSettingView: View {
             
             HStack {
                 Spacer()
-                Text("설정")
+                Text("프로필 설정")
                     .titleSemiBold18()
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.txtDisplayPrimary)
                 Spacer()
             }
             
@@ -62,7 +62,7 @@ struct ProfileSettingView: View {
 //        }
         .toolbar(.hidden, for: .navigationBar)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(.gray900)
+        .background(.bgDisplayPrimary)
         .ignoresSafeArea(.container, edges: .bottom)
         .sheet(isPresented: $showDatePicker, onDismiss: {
             focusedField = nil
@@ -124,13 +124,13 @@ struct ProfileSettingView: View {
         HStack {
             Text("현재 수입 있음")
                 .bodyMedium16()
-                .foregroundColor(.white)
+                .foregroundColor(.txtDisplayPrimary)
             
             Spacer()
             
             Toggle("", isOn: $viewModel.hasIncome)
                 .labelsHidden()
-                .tint(.primaryNormal)
+                .tint(.bgStatusFocused)
                 .onChange(of: viewModel.hasIncome) { _, newValue in
                     if !newValue {
                         viewModel.selectIncome(.none)
@@ -142,7 +142,7 @@ struct ProfileSettingView: View {
         .padding(.horizontal, 20)
         .background(
             RoundedRectangle(cornerRadius: 12)
-                .fill(.gray750)
+                .fill(.bgDisplayCard)
         )
         .padding(.top, 20)
     }
@@ -151,7 +151,7 @@ struct ProfileSettingView: View {
         VStack(alignment: .leading, spacing: 0) {
             Text("현재 수입은 어느 정도인가요?")
                 .titleSemiBold16()
-                .foregroundStyle(.gray100)
+                .foregroundStyle(.txtDisplaySecondary)
                 .padding(.bottom, 20)
             
             VStack(spacing: 12) {
@@ -165,7 +165,7 @@ struct ProfileSettingView: View {
         .padding(.bottom, 20)
         .background(
             RoundedRectangle(cornerRadius: 12)
-                .fill(.gray750)
+                .fill(.bgDisplayCard)
         )
         .transition(.asymmetric(
             insertion: .move(edge: .top).combined(with: .opacity),
@@ -183,13 +183,13 @@ struct ProfileSettingView: View {
             HStack {
                 Text(selection.displayText)
                     .bodyRegular14()
-                    .foregroundStyle(.gray100)
+                    .foregroundStyle(.txtInteractivePrimary)
                 
                 Spacer()
                 
                 if viewModel.isSelected(selection) {
                     Image(systemName: "checkmark")
-                        .foregroundStyle(.primaryNormal)
+                        .foregroundStyle(.txtStatusFocused)
                         .font(.system(size: 12, weight: .semibold))
                         .transition(.scale.combined(with: .opacity))
                 }
@@ -204,7 +204,7 @@ struct ProfileSettingView: View {
             .overlay(
                 RoundedRectangle(cornerRadius: 8)
                     .stroke(
-                        viewModel.isSelected(selection) ? .primaryNormal : .commonLineNormal,
+                        viewModel.isSelected(selection) ? .borderStatusFocused : .borderFieldDefault,
                         lineWidth: viewModel.isSelected(selection) ? 2 : 1
                     )
             )
@@ -227,12 +227,12 @@ struct ProfileSettingView: View {
                 
                 Text("봉투백서 시작하기")
                     .titleSemiBold18()
-                    .foregroundColor(viewModel.isStartButtonEnabled ? .white : .gray500)
+                    .foregroundColor(viewModel.isStartButtonEnabled ? .txtInteractiveInverse : .txtStatusDisabled)
             }
         }
         .frame(maxWidth: .infinity)
         .padding()
-        .background(viewModel.isStartButtonEnabled ? .primaryNormal : .primaryBg)
+        .background(viewModel.isStartButtonEnabled ? .bgStatusFocused : .btnInteractiveDisabled)
         .cornerRadius(12)
         .padding(.top, 20)
         .disabled(!viewModel.isStartButtonEnabled || viewModel.isSigningUp)

--- a/BongBaek/BongBaek/Presentation/Login/View/SignUpBottomSheetView.swift
+++ b/BongBaek/BongBaek/Presentation/Login/View/SignUpBottomSheetView.swift
@@ -53,7 +53,7 @@ struct SignUpBottomSheetView: View {
                 )
                 
                 Divider()
-                    .background(Color.gray.opacity(0.3))
+                    .background(.borderDisplayDivider)
                 
                 VStack(alignment: .leading, spacing: 16.adjustedH) {
                     CheckButton(
@@ -114,11 +114,11 @@ struct SignUpBottomSheetView: View {
                     Spacer()
                     Text("다음")
                         .titleSemiBold18()
-                        .foregroundColor(canProceed ? .white : .gray500)
+                        .foregroundColor(canProceed ? .txtInteractiveInverse : .txtStatusDisabled)
                     Spacer()
                 }
                 .frame(height: 55.adjustedH)
-                .background(canProceed ? .primaryNormal : Color.primaryBg)
+                .background(canProceed ? .bgStatusFocused : .btnInteractiveDisabled)
                 .cornerRadius(12)
             }
             .disabled(!canProceed)
@@ -127,7 +127,7 @@ struct SignUpBottomSheetView: View {
             .padding(.bottom,60.adjustedH)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(.gray750)
+        .background(.bgDisplayCard)
     }
     
     private func toggleAllAgree() {

--- a/BongBaek/BongBaek/Presentation/Login/View/SignUpBottomSheetView.swift
+++ b/BongBaek/BongBaek/Presentation/Login/View/SignUpBottomSheetView.swift
@@ -28,10 +28,10 @@ struct SignUpBottomSheetView: View {
             VStack(alignment: .leading){
                 Text("앱 사용을 위해 권한을 허용해주세요.")
                     .titleSemiBold18()
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.txtDisplayPrimary)
                 Text("서비스 이용에 필수적인 약관들이에요.")
                     .titleSemiBold18()
-                    .foregroundStyle(.white)
+                    .foregroundStyle(.txtDisplayPrimary)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.top,40.adjustedH)

--- a/BongBaek/BongBaek/Presentation/Login/View/WelcomeTextView.swift
+++ b/BongBaek/BongBaek/Presentation/Login/View/WelcomeTextView.swift
@@ -26,7 +26,7 @@ struct WelcomeTextView: View {
                 
                 HStack(spacing: 0) {
                     Text("봉투백서")
-                        .foregroundStyle(.white)
+                        .foregroundStyle(.txtDisplaySecondary)
                         .headBold26()
                     
                     Text("에 오신 것을")
@@ -44,8 +44,8 @@ struct WelcomeTextView: View {
             }
             
             Text("3초 가입으로 바로 시작해보세요")
-                .foregroundStyle(.gray100)
-                .bodyMedium16()
+                .foregroundStyle(.txtDisplaySecondary)
+                .bodyRegular16()
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/BongBaek/BongBaek/Presentation/Recommend/View/RecommendFlow/EventDateView.swift
+++ b/BongBaek/BongBaek/Presentation/Recommend/View/RecommendFlow/EventDateView.swift
@@ -396,7 +396,7 @@ struct DatePickerBottomSheet: View {
                     displayedComponents: .date
                 )
                 .datePickerStyle(.wheel)
-                .colorScheme(.dark)
+//                .colorScheme(.dark)
                 .environment(\.locale, Locale(identifier: "ko_KR"))
                 .background(
                     RoundedRectangle(cornerRadius: 12)
@@ -434,7 +434,7 @@ struct DatePickerBottomSheet: View {
             )
             .navigationBarTitleDisplayMode(.inline)
         }
-        .preferredColorScheme(.dark)
+//        .preferredColorScheme(.dark)
         .presentationDetents([.medium])
         .presentationDragIndicator(.visible)
     }


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->

- LoginView, SignUpBottomSheetView, ProfileSettingView 및 CustomTextField에 다크/라이트 모드에 따른 색상 적용할 수 있도록 지정해두었습니다.
- 바뀐 hextColor, ColorName 적용해두었습니다.

## 🎫 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- CustomTextField 상태별 색상 변경
- 각 textLabel, background 모드별 색상 바뀌게 적용할 수 있도록 Color Asset 값 수정 및 적용

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->

## 🎫 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   Light Mode   |   Dark Mode   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/5244b5e1-d655-4d72-9cc3-fa377f6e7e0e" width ="250"> | <img src = "https://github.com/user-attachments/assets/da256735-9c0f-4da4-b7fc-91b22d200a9e" width ="250"> |

## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

혹시 잘못 적용된 색상이나 적용이 안된 부분 발견하면 말씀해주시면 감사하겠습니다.

## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`HomeView`
- 쏼라쏼라
```swift
// 코드는 이 사이에 작성하면 됩니다. 
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #136 
