### PR TITLE
[Feat] 콘텐츠 API 작업, 바뀐 baseResponse 및 로그인 응답구조 적용 진행

### DIFF
--- a/BongBaek/BongBaek/Global/NavigationPathManager.swift
+++ b/BongBaek/BongBaek/Global/NavigationPathManager.swift
@@ -30,7 +30,7 @@ enum RecommendRoute: Hashable {
     case ModifyView(profileData: UpdateProfileData?)
     case profileSettingView
     case contentsView
-    case contentDetailView
+    case contentDetailView(contentId: String)
     
     var displayName: String {
         switch self {

--- a/BongBaek/BongBaek/Network/Base/DIContainer.swift
+++ b/BongBaek/BongBaek/Network/Base/DIContainer.swift
@@ -29,6 +29,13 @@ class DIContainer {
             plugins: [NetworkLoggerPlugin(configuration: .init(logOptions: .verbose))]
         )
     }()
+    
+    lazy var contentsProvider: MoyaProvider<ContentsTarget> = {
+        return MoyaProvider<ContentsTarget>(
+            plugins: [NetworkLoggerPlugin(configuration: .init(logOptions: .verbose))]
+        )
+        
+    }()
 
     lazy var authNetworkService: NetworkService<AuthTarget> = NetworkService(
         provider: authProvider
@@ -42,6 +49,8 @@ class DIContainer {
         provider: userProvider
     )
     
+    lazy var contentsNetworkService: NetworkService<ContentsTarget> = NetworkService(provider: contentsProvider)
+    
     lazy var authService: AuthServiceProtocol = AuthService(
         networkService: authNetworkService
     )
@@ -53,4 +62,6 @@ class DIContainer {
     lazy var userService: MyPageServiceProtocol = UserService(
         networkService: userNetworkService
     )
+    
+  //  lazy var contentsService: ContentsServiceProtocol =
 }

--- a/BongBaek/BongBaek/Network/Base/DIContainer.swift
+++ b/BongBaek/BongBaek/Network/Base/DIContainer.swift
@@ -63,5 +63,7 @@ class DIContainer {
         networkService: userNetworkService
     )
     
-  //  lazy var contentsService: ContentsServiceProtocol =
+    lazy var contentsService: ContentsServiceProtocol = ContentsService(
+        networkService: contentsNetworkService
+    )
 }

--- a/BongBaek/BongBaek/Network/Base/Environment.swift
+++ b/BongBaek/BongBaek/Network/Base/Environment.swift
@@ -13,7 +13,7 @@ struct EnvironmentSetting {
         case release
     }
     
-    static let current: APIEnvironment = .release
+    static let current: APIEnvironment = .test
 
     static var baseURL: String {
         switch current {

--- a/BongBaek/BongBaek/Network/Base/Managers/AuthManager.swift
+++ b/BongBaek/BongBaek/Network/Base/Managers/AuthManager.swift
@@ -314,7 +314,7 @@ class AuthManager: ObservableObject {
             return
         }
         
-        currentKakaoId = authData.kakaoId
+        currentKakaoId = authData.oauthId
         loginType = .kakao
         
         if let apiKey = authData.apiKey {
@@ -332,7 +332,7 @@ class AuthManager: ObservableObject {
             return
         }
         
-        currentAppleId = authData.appleId
+        currentAppleId = authData.oauthId
         loginType = .apple
         
         if let apiKey = authData.apiKey {
@@ -344,7 +344,7 @@ class AuthManager: ObservableObject {
     }
     
     /// 공통 AuthData 처리 (카카오용)
-    private func handleAuthData(_ authData: AuthData) {
+    private func handleAuthData(_ authData: OAuthData) {
         if authData.isCompletedSignUp {
             // 기존 회원
             guard let tokenInfo = authData.token else {
@@ -371,7 +371,7 @@ class AuthManager: ObservableObject {
     }
     
     /// 애플 AuthData 처리
-    private func handleAppleAuthData(_ authData: AppleAuthData) {
+    private func handleAppleAuthData(_ authData: OAuthData) {
         if authData.isCompletedSignUp {
             // 기존 회원
             guard let tokenInfo = authData.token else {

--- a/BongBaek/BongBaek/Network/Base/Managers/KaKaoLoginManager.swift
+++ b/BongBaek/BongBaek/Network/Base/Managers/KaKaoLoginManager.swift
@@ -17,16 +17,16 @@ class KakaoLoginManager {
                 UserApi.shared.loginWithKakaoTalk { oauthToken, error in
                     if let error = error {
                         continuation.resume(throwing: error)
-                    } else if let accessToken = oauthToken?.accessToken {
-                        continuation.resume(returning: accessToken)
+                    } else if let idToken = oauthToken?.idToken {
+                        continuation.resume(returning: idToken)
                     }
                 }
             } else {
                 UserApi.shared.loginWithKakaoAccount { oauthToken, error in
                     if let error = error {
                         continuation.resume(throwing: error)
-                    } else if let accessToken = oauthToken?.accessToken {
-                        continuation.resume(returning: accessToken)
+                    } else if let idToken = oauthToken?.idToken {
+                        continuation.resume(returning: idToken)
                     }
                 }
             }

--- a/BongBaek/BongBaek/Network/Base/Targets/AuthTarget.swift
+++ b/BongBaek/BongBaek/Network/Base/Targets/AuthTarget.swift
@@ -10,7 +10,7 @@ import Foundation
 
 
 struct LoginRequest: Codable {
-    let accessToken: String
+    let idToken: String
 }
 
 enum AuthTarget {
@@ -57,7 +57,7 @@ extension AuthTarget: TargetType {
     var task: Moya.Task {
         switch self {
         case .kakaoLogin(let accessToken):
-            let loginRequest = LoginRequest(accessToken: accessToken)
+            let loginRequest = LoginRequest(idToken: accessToken)
             return .requestJSONEncodable(loginRequest)
             
         case .signUp(let memberInfo):
@@ -67,7 +67,7 @@ extension AuthTarget: TargetType {
             return .requestPlain
             
         case .appleLogin(let idToken):
-            let loginRequest = LoginRequest(accessToken: idToken)
+            let loginRequest = LoginRequest(idToken: idToken)
             return .requestJSONEncodable(loginRequest)
         case .withdraw(let reason):
             return .requestJSONEncodable(reason)

--- a/BongBaek/BongBaek/Network/Base/Targets/ContentsTarget.swift
+++ b/BongBaek/BongBaek/Network/Base/Targets/ContentsTarget.swift
@@ -1,0 +1,71 @@
+//
+//  ContentsTarget.swift
+//  BongBaek
+//
+//  Created by 임재현 on 11/28/25.
+//
+
+import Foundation
+import Moya
+
+enum ContentsTarget {
+    case getContentsHome
+    case getContentsCategory(page: Int, category: String?)
+    case getContentsDetail(contentId: String)
+}
+
+extension ContentsTarget: TargetType {
+    
+    var baseURL: URL {
+        guard let url = URL(string: EnvironmentSetting.baseURL) else {
+            fatalError("Invalid base URL")
+        }
+        return url
+    }
+    
+    var path: String {
+        switch self {
+        case .getContentsHome:
+            return "/api/v1/content/home"
+        case .getContentsCategory(let page, let category):
+            var path = "/api/v1/content/list/\(page)"
+            if let category = category {
+                path += "?category=\(category)"
+            }
+            return path
+        case .getContentsDetail(let contentId):
+            return "/api/v1/content/\(contentId)"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getContentsHome,.getContentsCategory ,.getContentsDetail:
+            return .get
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .getContentsHome,.getContentsCategory ,.getContentsDetail:
+            return .requestPlain
+        }
+    }
+    
+    var headers: [String : String]? {
+        // 기본 헤더
+        var headers = [
+            "Content-Type": "application/json"
+        ]
+        
+        // KeyChain에서 accessToken 가져오기
+        if let accessToken = KeychainManager.shared.accessToken {
+            headers["Authorization"] = "Bearer \(accessToken)"
+            print("Authorization 헤더 추가됨: Bearer \(accessToken.prefix(10))...")
+        } else {
+            print("AccessToken이 KeyChain에 없습니다")
+        }
+        
+        return headers
+    }
+}

--- a/BongBaek/BongBaek/Network/Base/Targets/ContentsTarget.swift
+++ b/BongBaek/BongBaek/Network/Base/Targets/ContentsTarget.swift
@@ -28,11 +28,11 @@ extension ContentsTarget: TargetType {
         case .getContentsHome:
             return "/api/v1/content/home"
         case .getContentsCategory(let page, let category):
-            var path = "/api/v1/content/list/\(page)"
-            if let category = category {
-                path += "?category=\(category)"
-            }
-            return path
+            return "/api/v1/content/list/\(page)"
+//            if let category = category {
+//                path += "?category=\(category)"
+//            }
+//            return path
         case .getContentsDetail(let contentId):
             return "/api/v1/content/\(contentId)"
         }
@@ -47,8 +47,14 @@ extension ContentsTarget: TargetType {
     
     var task: Moya.Task {
         switch self {
-        case .getContentsHome,.getContentsCategory ,.getContentsDetail:
+        case .getContentsHome,.getContentsDetail:
             return .requestPlain
+        case .getContentsCategory(_, let category):
+            var params: [String: Any] = [:]
+            if let category = category {
+                params["category"] = category
+            }
+            return .requestParameters(parameters: params, encoding: URLEncoding.queryString)
         }
     }
     

--- a/BongBaek/BongBaek/Network/Model/Request/MemberInfo.swift
+++ b/BongBaek/BongBaek/Network/Model/Request/MemberInfo.swift
@@ -10,9 +10,11 @@ import SwiftUI
 struct MemberInfo: Codable {
     let kakaoId: String?
     let appleId: String?
+    let oauthId: String?
     let memberName: String
     let memberBirthday: String
     let memberIncome: String
+    let oauthProvider: String
     
     enum CodingKeys: String, CodingKey {
         case kakaoId
@@ -20,13 +22,17 @@ struct MemberInfo: Codable {
         case memberName
         case memberBirthday
         case memberIncome
+        case oauthId
+        case oauthProvider
     }
     
-    init(kakaoId: String?, appleId: String? = nil, memberName: String, memberBirthday: String, memberIncome: String) {
+    init(kakaoId: String?, appleId: String? = nil,oauthId: String?, memberName: String, memberBirthday: String, memberIncome: String,oauthProvider: String) {
         self.kakaoId = kakaoId
         self.appleId = appleId
+        self.oauthId = oauthId
         self.memberName = memberName
         self.memberBirthday = memberBirthday
         self.memberIncome = memberIncome
+        self.oauthProvider = oauthProvider
     }
 }

--- a/BongBaek/BongBaek/Network/Model/Response/BaseResponse.swift
+++ b/BongBaek/BongBaek/Network/Model/Response/BaseResponse.swift
@@ -7,14 +7,25 @@
 
 import Foundation
 
+//struct BaseResponse<T: Codable>: Codable {
+//    let success: Bool
+//    let status: Int
+//    let message: String
+//    let data: T?
+//    
+//    var isSuccess: Bool {
+//        return success && status < 400
+//    }
+//}
+
 struct BaseResponse<T: Codable>: Codable {
-    let success: Bool
     let status: Int
+    let code: String
     let message: String
     let data: T?
     
     var isSuccess: Bool {
-        return success && status < 400
+        return status >= 200 && status < 300
     }
 }
 

--- a/BongBaek/BongBaek/Network/Model/Response/BaseResponse.swift
+++ b/BongBaek/BongBaek/Network/Model/Response/BaseResponse.swift
@@ -17,3 +17,14 @@ struct BaseResponse<T: Codable>: Codable {
         return success && status < 400
     }
 }
+
+struct BaseResponseV2<T: Codable>: Codable {
+    let status: Int
+    let code: String
+    let message: String
+    let data: T?
+    
+    var isSuccess: Bool {
+        return status >= 200 && status < 300
+    }
+}

--- a/BongBaek/BongBaek/Network/Model/Response/ContentsHomeResponse.swift
+++ b/BongBaek/BongBaek/Network/Model/Response/ContentsHomeResponse.swift
@@ -1,0 +1,21 @@
+//
+//  ContentsHomeResponse.swift
+//  BongBaek
+//
+//  Created by 임재현 on 11/28/25.
+//
+
+import Foundation
+
+typealias ContentsHomeResponse = BaseResponseV2<ContentsHomeResponseData>
+
+struct ContentsHomeResponseData: Codable {
+    let contents: [ContentHomeItem]
+}
+
+struct ContentHomeItem: Codable {
+    let contentId: String
+    let contentTitle: String
+    let contentCategory: String
+    let thumbnailUrl: String
+}

--- a/BongBaek/BongBaek/Network/Model/Response/MoreContentsDetailResponse.swift
+++ b/BongBaek/BongBaek/Network/Model/Response/MoreContentsDetailResponse.swift
@@ -1,0 +1,14 @@
+//
+//  MoreContentsDetailResponse.swift
+//  BongBaek
+//
+//  Created by 임재현 on 12/5/25.
+//
+
+import Foundation
+
+typealias MoreContentsDetailResponse = BaseResponseV2<MoreContentsDetailResponseData>
+
+struct MoreContentsDetailResponseData: Codable {
+    let contents: [MoreContentItem]
+}

--- a/BongBaek/BongBaek/Network/Model/Response/MoreContentsDetailResponse.swift
+++ b/BongBaek/BongBaek/Network/Model/Response/MoreContentsDetailResponse.swift
@@ -10,5 +10,9 @@ import Foundation
 typealias MoreContentsDetailResponse = BaseResponseV2<MoreContentsDetailResponseData>
 
 struct MoreContentsDetailResponseData: Codable {
-    let contents: [MoreContentItem]
+    let contentId: String
+    let contentTitle: String
+    let contentCategory: String
+    let imageUrls: [String]
+    let createdAt: String
 }

--- a/BongBaek/BongBaek/Network/Model/Response/MoreContentsResponse.swift
+++ b/BongBaek/BongBaek/Network/Model/Response/MoreContentsResponse.swift
@@ -1,0 +1,26 @@
+//
+//  MoreContentsResponse.swift
+//  BongBaek
+//
+//  Created by 임재현 on 12/4/25.
+//
+
+import Foundation
+
+typealias MoreContentsResponse = BaseResponseV2<MoreContentsResponseData>
+
+struct MoreContentsResponseData: Codable {
+    let contents: [MoreContentItem]
+    let currentPage: Int
+    let totalPages: Int
+    let totalElements: Int
+    let isLast: Bool
+}
+
+struct MoreContentItem: Codable {
+    let contentId: String
+    let contentTitle: String
+    let contentCategory: String
+    let thumbnailUrl: String
+    let createdAt: String
+}

--- a/BongBaek/BongBaek/Network/Model/Response/SignUpResponseData.swift
+++ b/BongBaek/BongBaek/Network/Model/Response/SignUpResponseData.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 typealias SignUpResponse = BaseResponse<AuthResponseData>
-typealias KaKaoLoginResponse = BaseResponse<AuthData>
-typealias AppleLoginResponse = BaseResponse<AppleAuthData>
+typealias KaKaoLoginResponse = BaseResponse<OAuthData>
+typealias AppleLoginResponse = BaseResponse<OAuthData>
 typealias RefreshTokenResponse = BaseResponse<TokenInfo>
 typealias LogoutResponse = BaseResponse<EmptyData>
 typealias WithdrawResponse = BaseResponse<EmptyData>
@@ -22,11 +22,21 @@ struct AuthData: Codable {
     let apiKey: String?
 }
 
+struct OAuthData: Codable {
+    let name: String?
+    let token: TokenInfo?
+    let isCompletedSignUp: Bool
+    let oauthId: String?
+    let oauthProvider: String?
+    let apiKey: String?
+    let kakaoAccessToken: String?
+}
+
 struct AppleAuthData: Codable {
     let name: String?
     let token: TokenInfo?
     let isCompletedSignUp: Bool
-    let appleId: String
+    let appleId: String?
     let apiKey: String?
 }
 

--- a/BongBaek/BongBaek/Network/Protocols/ContentsServiceProtocol.swift
+++ b/BongBaek/BongBaek/Network/Protocols/ContentsServiceProtocol.swift
@@ -9,5 +9,5 @@ import Foundation
 import Combine
 
 protocol ContentsServiceProtocol {
-    func getHomeContents() -> AnyPublisher<ContentsHomeResponse, Error>
+    func getHomeContents() async throws -> ContentsHomeResponse
 }

--- a/BongBaek/BongBaek/Network/Protocols/ContentsServiceProtocol.swift
+++ b/BongBaek/BongBaek/Network/Protocols/ContentsServiceProtocol.swift
@@ -11,4 +11,5 @@ import Combine
 protocol ContentsServiceProtocol {
     func getHomeContents() async throws -> ContentsHomeResponse
     func getMoreContents(page: Int, category: String?) async throws -> MoreContentsResponse
+    func getMoreContentsDetail(contentId: String) async throws -> MoreContentsDetailResponse
 }

--- a/BongBaek/BongBaek/Network/Protocols/ContentsServiceProtocol.swift
+++ b/BongBaek/BongBaek/Network/Protocols/ContentsServiceProtocol.swift
@@ -10,4 +10,5 @@ import Combine
 
 protocol ContentsServiceProtocol {
     func getHomeContents() async throws -> ContentsHomeResponse
+    func getMoreContents(page: Int, category: String?) async throws -> MoreContentsResponse
 }

--- a/BongBaek/BongBaek/Network/Protocols/ContentsServiceProtocol.swift
+++ b/BongBaek/BongBaek/Network/Protocols/ContentsServiceProtocol.swift
@@ -9,5 +9,5 @@ import Foundation
 import Combine
 
 protocol ContentsServiceProtocol {
-
+    func getHomeContents() -> AnyPublisher<ContentsHomeResponse, Error>
 }

--- a/BongBaek/BongBaek/Network/Protocols/ContentsServiceProtocol.swift
+++ b/BongBaek/BongBaek/Network/Protocols/ContentsServiceProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  ContentsServiceProtocol.swift
+//  BongBaek
+//
+//  Created by 임재현 on 11/28/25.
+//
+
+import Foundation
+import Combine
+
+protocol ContentsServiceProtocol {
+
+}

--- a/BongBaek/BongBaek/Network/Services/ContentsService.swift
+++ b/BongBaek/BongBaek/Network/Services/ContentsService.swift
@@ -23,4 +23,12 @@ class ContentsService: ContentsServiceProtocol {
         )
         .async() 
     }
+    
+    func getMoreContents(page: Int, category: String?) async throws -> MoreContentsResponse {
+        return try await networkService.request(
+            .getContentsCategory(page: page, category: category),
+            responseType: MoreContentsResponse.self
+        )
+        .async()
+    }
 }

--- a/BongBaek/BongBaek/Network/Services/ContentsService.swift
+++ b/BongBaek/BongBaek/Network/Services/ContentsService.swift
@@ -1,0 +1,25 @@
+//
+//  ContentsService.swift
+//  BongBaek
+//
+//  Created by 임재현 on 11/28/25.
+//
+
+import Foundation
+import Combine
+
+class ContentsService: ContentsServiceProtocol {
+
+    private let networkService: NetworkService<ContentsTarget>
+    
+    init(networkService: NetworkService<ContentsTarget>) {
+        self.networkService = networkService
+    }
+    
+    func getHomeContents() -> AnyPublisher<ContentsHomeResponse, Error> {
+        return networkService.request(
+            .getContentsHome,
+            responseType: ContentsHomeResponse.self
+        )
+    }
+}

--- a/BongBaek/BongBaek/Network/Services/ContentsService.swift
+++ b/BongBaek/BongBaek/Network/Services/ContentsService.swift
@@ -31,4 +31,13 @@ class ContentsService: ContentsServiceProtocol {
         )
         .async()
     }
+    
+    func getMoreContentsDetail(contentId: String) async throws -> MoreContentsDetailResponse {
+        return try await networkService.request(
+            .getContentsDetail(contentId: contentId),
+            responseType: MoreContentsDetailResponse.self
+        )
+        .async()
+    }
+        
 }

--- a/BongBaek/BongBaek/Network/Services/ContentsService.swift
+++ b/BongBaek/BongBaek/Network/Services/ContentsService.swift
@@ -16,10 +16,11 @@ class ContentsService: ContentsServiceProtocol {
         self.networkService = networkService
     }
     
-    func getHomeContents() -> AnyPublisher<ContentsHomeResponse, Error> {
-        return networkService.request(
+    func getHomeContents() async throws -> ContentsHomeResponse {
+        return try await networkService.request(
             .getContentsHome,
             responseType: ContentsHomeResponse.self
         )
+        .async() 
     }
 }

--- a/BongBaek/BongBaek/Presentation/ContentDetailView.swift
+++ b/BongBaek/BongBaek/Presentation/ContentDetailView.swift
@@ -11,9 +11,6 @@ struct ContentDetailView: View {
     @EnvironmentObject var router: NavigationRouter
     @StateObject private var viewModel = ContentDetailViewModel()
     let contentId: String
-        
-    
-    let cardImages = ["image1", "image2"]
     
     var body: some View {
         VStack(spacing: 0) {
@@ -21,46 +18,108 @@ struct ContentDetailView: View {
                 router.pop()
             }
             
-            ScrollView(showsIndicators: false) {
-                VStack(alignment: .leading, spacing: 0) {
-                    VStack(alignment: .leading, spacing: 0) {
-                        Text("경조사 유형")
-                            .captionRegular12()
-                            .foregroundStyle(.txtStatusFocused)
-                        
-                        Text("이제는 알아야 할 결혼식 식사 예절")
-                            .titleSemiBold20()
-                            .foregroundStyle(.txtDisplayPrimary)
-                            .padding(.top, 2)
-                            
-                        Text("2025. 01. 01")
-                            .bodyRegular14()
-                            .foregroundStyle(.txtDisplayTierary)
-                            .padding(.top, 8)
-                    }
-                    .padding(.horizontal, 20)
-                    
-                    VStack(spacing: 8) {
-                        ForEach(cardImages.indices, id: \.self) { index in
-                            Image(cardImages[index])
-                                .resizable()
-                                .scaledToFit()
-                                .frame(maxWidth: .infinity)
-                                .background(Color.gray.opacity(0.2))
-                        }
-                    }
-                    .padding(.top, 24)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.top, 20)
-                .padding(.bottom, 20)
+            if viewModel.isLoading {
+                loadingView
+            } else if viewModel.hasError {
+                errorView
+            } else if let detail = viewModel.contentDetail {
+                contentDetailView(detail)
             }
-            .task {
-                await viewModel.loadContentDetail(contentId: contentId)
-            }
+        }
+        .task {
+            await viewModel.loadContentDetail(contentId: contentId)
         }
         .navigationBarBackButtonHidden(true)
         .background(Color.bgDisplayPrimary)
     }
-}
+    
+    private func contentDetailView(_ detail: MoreContentsDetailResponseData) -> some View {
+        ScrollView(showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(detail.contentCategory)
+                        .captionRegular12()
+                        .foregroundStyle(.txtStatusFocused)
+                    
+                    Text(detail.contentTitle)
+                        .titleSemiBold20()
+                        .foregroundStyle(.txtDisplayPrimary)
+                        .padding(.top, 2)
+                        
+                    Text(detail.createdAt)
+                        .bodyRegular14()
+                        .foregroundStyle(.txtDisplayTierary)
+                        .padding(.top, 8)
+                }
+                .padding(.horizontal, 20)
+                
+                VStack(spacing: 8) {
+                    ForEach(detail.imageUrls, id: \.self) { imageUrl in
+                        AsyncImage(url: URL(string: imageUrl)) { phase in
+                            switch phase {
+                            case .empty:
+                                Color.gray300
+                                    .frame(height: 200)
+                            case .success(let image):
+                                image
+                                    .resizable()
+                                    .scaledToFit()
+                            case .failure:
+                                Color.gray300
+                                    .frame(height: 200)
+                                    .overlay(
+                                        Image(systemName: "photo")
+                                            .foregroundColor(.gray)
+                                    )
+                            @unknown default:
+                                EmptyView()
+                            }
+                        }
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+                .padding(.top, 24)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, 20)
+            .padding(.bottom, 20)
+        }
+    }
+    
+    private var loadingView: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .tint(.primaryNormal)
+            Text("콘텐츠를 불러오는 중...")
+                .bodyRegular14()
+                .foregroundColor(.txtDisplayTierary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
 
+    private var errorView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 40))
+                .foregroundColor(.red)
+            
+            Text(viewModel.errorMessage ?? "알 수 없는 오류가 발생했습니다")
+                .bodyRegular14()
+                .foregroundColor(.txtDisplayTierary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 20)
+            
+            Button("다시 시도") {
+                Task {
+                    await viewModel.loadContentDetail(contentId: contentId)
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 12)
+            .background(Color.primaryNormal)
+            .foregroundColor(.white)
+            .cornerRadius(8)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/BongBaek/BongBaek/Presentation/ContentDetailView.swift
+++ b/BongBaek/BongBaek/Presentation/ContentDetailView.swift
@@ -116,8 +116,8 @@ struct ContentDetailView: View {
             }
             .padding(.horizontal, 24)
             .padding(.vertical, 12)
-            .background(Color.primaryNormal)
-            .foregroundColor(.white)
+            .background(.bgStatusFocused)
+            .foregroundColor(.txtInteractiveInverse)
             .cornerRadius(8)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/BongBaek/BongBaek/Presentation/ContentDetailView.swift
+++ b/BongBaek/BongBaek/Presentation/ContentDetailView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 
 struct ContentDetailView: View {
     @EnvironmentObject var router: NavigationRouter
+    @StateObject private var viewModel = ContentDetailViewModel()
+    let contentId: String
+        
     
     let cardImages = ["image1", "image2"]
     
@@ -51,6 +54,9 @@ struct ContentDetailView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.top, 20)
                 .padding(.bottom, 20)
+            }
+            .task {
+                await viewModel.loadContentDetail(contentId: contentId)
             }
         }
         .navigationBarBackButtonHidden(true)

--- a/BongBaek/BongBaek/Presentation/ContentDetailViewModel.swift
+++ b/BongBaek/BongBaek/Presentation/ContentDetailViewModel.swift
@@ -1,0 +1,62 @@
+//
+//  ContentDetailViewModel.swift
+//  BongBaek
+//
+//  Created by 임재현 on 12/5/25.
+//
+
+import Foundation
+import Combine
+
+
+@MainActor
+class ContentDetailViewModel: ObservableObject {
+    
+    @Published var contentDetail: MoreContentsDetailResponseData?
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+    
+    private let contentsService: ContentsServiceProtocol
+    private var cancellables = Set<AnyCancellable>()
+    
+    init() {
+        self.contentsService = DIContainer.shared.contentsService
+    }
+    
+    var hasData: Bool {
+        contentDetail != nil
+    }
+    
+    var hasError: Bool {
+        errorMessage != nil
+    }
+    
+    /// 콘텐츠 상세 조회
+    func loadContentDetail(contentId: String) async {
+        guard !isLoading else { return }
+        
+        isLoading = true
+        errorMessage = nil
+        
+        do {
+            let response = try await contentsService.getMoreContentsDetail(contentId: contentId)
+            
+            if response.isSuccess, let data = response.data {
+                self.contentDetail = data
+                print("콘텐츠 상세 조회 성공: \(data)")
+            } else {
+                errorMessage = response.message
+                print("콘텐츠 상세 조회 실패: \(response.message)")
+            }
+        } catch {
+            errorMessage = "콘텐츠를 불러오는데 실패했습니다: \(error.localizedDescription)"
+            print("콘텐츠 상세 조회 에러: \(error)")
+        }
+        
+        isLoading = false
+    }
+    
+    func clearError() {
+        errorMessage = nil
+    }
+}

--- a/BongBaek/BongBaek/Presentation/ContentViewModel.swift
+++ b/BongBaek/BongBaek/Presentation/ContentViewModel.swift
@@ -11,8 +11,8 @@ import Combine
 @MainActor
 class ContentViewModel: ObservableObject {
     
-    @Published var contents: [ContentHomeItem] = []
-    @Published var filteredContents: [ContentHomeItem] = []
+    @Published var contents: [MoreContentItem] = []
+    @Published var filteredContents: [MoreContentItem] = []
     @Published var isLoading: Bool = false
     @Published var isLoadingMore: Bool = false
     @Published var errorMessage: String?
@@ -55,6 +55,7 @@ class ContentViewModel: ObservableObject {
         currentPage = 0
         isLastPage = false
         contents.removeAll()
+        filteredContents.removeAll()
         
         await loadContents(isRefresh: true)
         
@@ -81,27 +82,41 @@ class ContentViewModel: ObservableObject {
     /// 실제 API 호출 메서드
     private func loadContents(isRefresh: Bool) async {
         do {
-            let response = try await contentsService.getHomeContents()
+            let categoryParam = selectedCategory == .all ? nil : selectedCategory.rawValue
+            let response = try await contentsService.getMoreContents(
+                page: currentPage,
+                category: categoryParam
+            )
             
             if response.isSuccess, let data = response.data {
                 let newContents = data.contents
                 
+                isLastPage = data.isLast
+                hasMoreData = !data.isLast
+                
                 if isRefresh {
                     self.contents = newContents
+                    self.filteredContents = newContents
                 } else {
                     self.contents.append(contentsOf: newContents)
+                    self.filteredContents.append(contentsOf: newContents)
                 }
                 
-                applyFilter()
+//                applyFilter()
                 
-                print("콘텐츠 로드 성공: \(newContents.count)개")
+                print("콘텐츠 로드 성공: \(newContents.count)개, 마지막페이지: \(data.isLast)")
             } else {
                 errorMessage = response.message
+                isLastPage = true
+                hasMoreData = false
                 print("콘텐츠 로드 실패: \(response.message)")
+                
             }
         } catch {
             errorMessage = "콘텐츠를 불러오는데 실패했습니다: \(error.localizedDescription)"
             print("콘텐츠 로드 에러: \(error)")
+            isLastPage = true
+            hasMoreData = false
         }
     }
     /// 카테고리 필터 적용'
@@ -124,17 +139,17 @@ class ContentViewModel: ObservableObject {
     }
     
     /// 카테고리 변경 (새로 로드)
-    func updateCategory(_ category: ScheduleCategory) {
+    func updateCategory(_ category: ScheduleCategory) async {
         guard selectedCategory != category else { return }
         
         selectedCategory = category
         print("카테고리 변경: \(category.displayName)")
-        
-        applyFilter()
+        await loadAllContents()
+       // applyFilter()
     }
     
     /// 무한스크롤 트리거 확인
-    func shouldLoadMore(for content: ContentHomeItem) -> Bool {
+    func shouldLoadMore(for content: MoreContentItem) -> Bool {
         guard let lastContent = filteredContents.last else { return false }
         return content.contentId == lastContent.contentId && !isLastPage && !isLoadingMore
     }

--- a/BongBaek/BongBaek/Presentation/ContentViewModel.swift
+++ b/BongBaek/BongBaek/Presentation/ContentViewModel.swift
@@ -11,8 +11,8 @@ import Combine
 @MainActor
 class ContentViewModel: ObservableObject {
     
-    @Published var guides: [Guide] = []
-    @Published var filteredGuides: [Guide] = []
+    @Published var contents: [ContentHomeItem] = []
+    @Published var filteredContents: [ContentHomeItem] = []
     @Published var isLoading: Bool = false
     @Published var isLoadingMore: Bool = false
     @Published var errorMessage: String?
@@ -24,19 +24,17 @@ class ContentViewModel: ObservableObject {
     private var isLastPage: Bool = false
     private var isLoadingData: Bool = false
     
-    private let eventService: EventServiceProtocol
+    private let contentsService: ContentsServiceProtocol
     private var cancellables = Set<AnyCancellable>()
     
     init() {
-        self.eventService = DIContainer.shared.eventService
-        self.guides = Guide.mockGuides
-        self.filteredGuides = Guide.mockGuides
+        self.contentsService = DIContainer.shared.contentsService
     }
     
     // MARK: - Computed Properties
     
     var hasData: Bool {
-        !filteredGuides.isEmpty
+        !filteredContents.isEmpty
     }
     
     var hasError: Bool {
@@ -46,7 +44,7 @@ class ContentViewModel: ObservableObject {
     // MARK: - API Methods
     
     /// 첫 페이지 로드 (새로고침/카테고리 변경 시)
-    func loadAllEvents() async {
+    func loadAllContents() async {
         guard !isLoadingData else { return }
         
         isLoading = true
@@ -56,16 +54,16 @@ class ContentViewModel: ObservableObject {
         // 페이지네이션 상태 초기화
         currentPage = 0
         isLastPage = false
-        guides.removeAll()
+        contents.removeAll()
         
-        await loadEvents(isRefresh: true)
+        await loadContents(isRefresh: true)
         
         isLoading = false
         isLoadingData = false
     }
     
     /// 다음 페이지 로드 (무한스크롤)
-    func loadMoreEvents() async {
+    func loadMoreContents() async {
         guard !isLoadingData && !isLastPage else { return }
         
         print("더 많은 이벤트 로드 - 페이지: \(currentPage + 1)")
@@ -74,82 +72,71 @@ class ContentViewModel: ObservableObject {
         isLoadingData = true
         
         currentPage += 1
-        await loadEvents(isRefresh: false)
+        await loadContents(isRefresh: false)
         
         isLoadingMore = false
         isLoadingData = false
     }
     
     /// 실제 API 호출 메서드
-    private func loadEvents(isRefresh: Bool) async {
-//        do {
-//            let categoryParam = selectedCategory == .all ? nil : selectedCategory.apiValue
-//            
-//            print("이벤트 로드 - 페이지: \(currentPage), 카테고리: \(categoryParam ?? "전체")")
-//            
-//            let response = try await eventService.getUpcomingEvents(page: currentPage, category: categoryParam)
-//                .async()
-//            
-//            if response.isSuccess, let data = response.data {
-//                let newEvents = data.events
-//                
-//                if isRefresh {
-//                    guides = newEvents
-//                } else {
-//                    guides.append(contentsOf: newEvents)
-//                }
-//                
-//                isLastPage = data.isLast
-//                
-//                print(guides)
-//                
-//                print("이벤트 로드 성공:")
-//                print("  - 새로 로드된 이벤트: \(newEvents.count)개")
-//                print("  - 전체 이벤트: \(guides.count)개")
-//                print("  - 현재 페이지: \(currentPage)")
-//                print("  - 마지막 페이지: \(isLastPage)")
-//                
-//            } else {
-//                errorMessage = response.message
-//                print("이벤트 로드 실패: \(response.message)")
-//            }
-//            
-//        } catch {
-//            errorMessage = "이벤트를 불러오는데 실패했습니다: \(error.localizedDescription)"
-//            print("이벤트 로드 에러: \(error)")
-//        }
-        
-        
+    private func loadContents(isRefresh: Bool) async {
+        do {
+            let response = try await contentsService.getHomeContents()
+            
+            if response.isSuccess, let data = response.data {
+                let newContents = data.contents
+                
+                if isRefresh {
+                    self.contents = newContents
+                } else {
+                    self.contents.append(contentsOf: newContents)
+                }
+                
+                applyFilter()
+                
+                print("콘텐츠 로드 성공: \(newContents.count)개")
+            } else {
+                errorMessage = response.message
+                print("콘텐츠 로드 실패: \(response.message)")
+            }
+        } catch {
+            errorMessage = "콘텐츠를 불러오는데 실패했습니다: \(error.localizedDescription)"
+            print("콘텐츠 로드 에러: \(error)")
+        }
     }
+    /// 카테고리 필터 적용'
+    private func applyFilter() {
+        if selectedCategory == .all {
+            filteredContents = contents
+        } else {
+            filteredContents = contents.filter {
+                $0.contentCategory == selectedCategory.rawValue
+            }
+        }
+        print("필터링된 콘텐츠 수: \(filteredContents.count)개")
+    }
+
     
     /// 새로고침
-    func refreshEvents() async {
-        print(" 이벤트 새로고침")
-        await loadAllEvents()
+    func refreshContents() async {
+        print(" 콘텐츠 새로고침")
+        await loadAllContents()
     }
     
     /// 카테고리 변경 (새로 로드)
     func updateCategory(_ category: ScheduleCategory) {
-         guard selectedCategory != category else { return }
-         
-         selectedCategory = category
-         print("카테고리 변경: \(category.displayName)")
-         
-         // 카테고리별 필터링
-         if category == .all {
-             filteredGuides = guides
-         } else {
-             filteredGuides = guides.filter { $0.category == category }
-         }
-         
-         print("필터링된 가이드 수: \(filteredGuides.count)개")
-     }
+        guard selectedCategory != category else { return }
+        
+        selectedCategory = category
+        print("카테고리 변경: \(category.displayName)")
+        
+        applyFilter()
+    }
     
     /// 무한스크롤 트리거 확인
-    func shouldLoadMore(for event: AttendedEvent) -> Bool {
-//        guard let lastEvent = guides.last else { return false }
-//        return event.eventId == lastEvent.eventId && !isLastPage && !isLoadingMore
-        return false
+    func shouldLoadMore(for content: ContentHomeItem) -> Bool {
+        guard let lastContent = filteredContents.last else { return false }
+        return content.contentId == lastContent.contentId && !isLastPage && !isLoadingMore
     }
     
     func clearError() {

--- a/BongBaek/BongBaek/Presentation/ContentsView.swift
+++ b/BongBaek/BongBaek/Presentation/ContentsView.swift
@@ -151,7 +151,7 @@ struct ContentsView: View {
             
             Button("다시 시도") {
                 Task {
-                    await viewModel.loadAllEvents()
+                    await viewModel.loadAllContents()
                 }
             }
             .foregroundColor(.primaryNormal)
@@ -195,26 +195,29 @@ struct ContentsView: View {
 
 }
 
-struct GuideCell: View {
-    let guide: Guide
+struct ContentCell: View {
+    let content: ContentHomeItem
     
     var body: some View {
         ZStack(alignment: .bottomLeading) {
-            Image(guide.backgroundImage)
-                .resizable()
-                .scaledToFill()
-                .frame(height: 251)
-                .clipped()
-                .overlay(
-                    LinearGradient(
-                        gradient: Gradient(colors: [.clear, .black.opacity(0.7)]),
-                        startPoint: .top,
-                        endPoint: .bottom
-                    )
+            AsyncImage(url: URL(string: content.thumbnailUrl)) { image in
+                image
+                    .resizable()
+                    .scaledToFill()
+            } placeholder: {
+                Color.gray300
+            }
+            .frame(height: 251)
+            .clipped()
+            .overlay(
+                LinearGradient(
+                    gradient: Gradient(colors: [.clear, .black.opacity(0.7)]),
+                    startPoint: .top,
+                    endPoint: .bottom
                 )
-            
+            )
             VStack(alignment: .leading, spacing: 8) {
-                Text(guide.category.displayName)
+                Text(content.contentCategory)
                     .captionRegular12()
                     .foregroundStyle(.txtDisplayPrimary)
                     .padding(.vertical, 2)
@@ -224,11 +227,11 @@ struct GuideCell: View {
                             .fill(Color.bgDisplayCard)
                     )
                 
-                Text(guide.title)
+                Text(content.contentTitle)
                     .titleSemiBold18()
                     .foregroundStyle(.txtInteractiveInverse)
                 
-                Text(guide.date)
+                Text("0000년 00월 00일")
                     .captionRegular12()
                     .foregroundStyle(.txtDisplayTierary)
             }

--- a/BongBaek/BongBaek/Presentation/ContentsView.swift
+++ b/BongBaek/BongBaek/Presentation/ContentsView.swift
@@ -53,7 +53,13 @@ struct ContentsView: View {
                 .padding(.top, 20)
                 .padding(.bottom, 20)
             }
+            .refreshable {  
+                await viewModel.refreshContents()
+            }
             
+        }
+        .task {
+            await viewModel.loadAllContents()
         }
         .background(Color.bgDisplayPrimary)
         
@@ -97,7 +103,7 @@ struct ContentsView: View {
             
             Spacer()
             
-            Text("\(viewModel.filteredGuides.count)개")
+            Text("\(viewModel.filteredContents.count)개")
                 .bodyRegular16()
                 .foregroundStyle(.txtDisplaySecondary)
             
@@ -130,7 +136,7 @@ struct ContentsView: View {
                 .progressViewStyle(CircularProgressViewStyle(tint: .primaryNormal))
                 .scaleEffect(0.8)
             
-            Text("더 많은 일정을 불러오는 중...")
+            Text("더 많은 콘텐츠를 불러오는 중...")
                 .bodyRegular14()
                 .foregroundColor(.gray400)
         }
@@ -164,7 +170,7 @@ struct ContentsView: View {
         VStack(spacing: 16) {
             ProgressView()
                 .tint(.primaryNormal)
-            Text("이벤트 정보를 불러오는 중...")
+            Text("콘텐츠 정보를 불러오는 중...")
                 .bodyRegular14()
                 .foregroundColor(.gray400)
         }
@@ -174,13 +180,17 @@ struct ContentsView: View {
     
     @ViewBuilder
     private var guideContentView: some View {
-        ForEach(viewModel.filteredGuides) { guide in
-            GuideCell(guide: guide)
+        ForEach(viewModel.filteredContents, id: \.contentId) { content in
+            ContentCell(content: content)
                 .onTapGesture {
                     router.push(to: .contentDetailView)
                 }
                 .onAppear {
-                    // 페이지네이션 처리
+                    if viewModel.shouldLoadMore(for: content) {
+                        Task {
+                            await viewModel.loadMoreContents()
+                        }
+                    }
                 }
         }
         

--- a/BongBaek/BongBaek/Presentation/ContentsView.swift
+++ b/BongBaek/BongBaek/Presentation/ContentsView.swift
@@ -185,7 +185,7 @@ struct ContentsView: View {
         ForEach(viewModel.filteredContents, id: \.contentId) { content in
             ContentCell(content: content)
                 .onTapGesture {
-                    router.push(to: .contentDetailView)
+                    router.push(to: .contentDetailView(contentId: content.contentId))
                 }
                 .onAppear {
                     if viewModel.shouldLoadMore(for: content) {

--- a/BongBaek/BongBaek/Presentation/ContentsView.swift
+++ b/BongBaek/BongBaek/Presentation/ContentsView.swift
@@ -81,7 +81,9 @@ struct ContentsView: View {
     private func categoryButton(for category: ScheduleCategory) -> some View {
         Button(action: {
             selectedCategory = category
-            viewModel.updateCategory(category)
+            Task {
+                await viewModel.updateCategory(category)
+            }
         }) {
             Text(category.displayName)
                 .bodyMedium16()
@@ -206,7 +208,7 @@ struct ContentsView: View {
 }
 
 struct ContentCell: View {
-    let content: ContentHomeItem
+    let content: MoreContentItem
     
     var body: some View {
         ZStack(alignment: .bottomLeading) {

--- a/BongBaek/BongBaek/Presentation/Home/Contents/ContentsCardView.swift
+++ b/BongBaek/BongBaek/Presentation/Home/Contents/ContentsCardView.swift
@@ -15,7 +15,7 @@ struct ContentsCardView: View {
     
     var body: some View {
         Button(action : {
-            router.push(to : .contentDetailView)
+            router.push(to : .contentDetailView(contentId: ""))
         }){
             ZStack(alignment: .topLeading){
                 RoundedRectangle(cornerRadius: 6)

--- a/BongBaek/BongBaek/Presentation/Home/MainTabView.swift
+++ b/BongBaek/BongBaek/Presentation/Home/MainTabView.swift
@@ -200,8 +200,8 @@ struct MainTabView: View {
             ContentsView()
                 .environmentObject(router)
             
-        case .contentDetailView:
-            ContentDetailView()
+        case .contentDetailView(let contentId):
+            ContentDetailView(contentId: contentId)
                 .environmentObject(router)
         }
     }

--- a/BongBaek/BongBaek/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/BongBaek/BongBaek/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -78,7 +78,7 @@ class LoginViewModel: ObservableObject {
                             }
                         } else {
                             // ToDo: - 신규 회원/회원가입 필요
-                            self?.navigateToSignUp(kakaoId: data.kakaoId, kakaoAccessToken: data.kakaoAccessToken)
+                            self?.navigateToSignUp(kakaoId: data.oauthId ?? "", kakaoAccessToken: data.kakaoAccessToken)
                         }
                     } else {
                         self?.errorMessage = response.message

--- a/BongBaek/BongBaek/Presentation/Login/ViewModel/ProfileSettingViewModel.swift
+++ b/BongBaek/BongBaek/Presentation/Login/ViewModel/ProfileSettingViewModel.swift
@@ -188,20 +188,24 @@ class ProfileSettingViewModel: ObservableObject {
         switch authManager.loginType {
         case .kakao:
             return MemberInfo(
-                kakaoId: authManager.currentKakaoId,
+                kakaoId: nil,
                 appleId: nil,
+                oauthId: authManager.currentKakaoId,
                 memberName: nickname,
                 memberBirthday: formattedBirthday,
-                memberIncome: incomeValue
+                memberIncome: incomeValue,
+                oauthProvider: "kakao"
             )
             
         case .apple:
             return MemberInfo(
                 kakaoId: nil,
-                appleId: authManager.currentAppleId,
+                appleId: nil,
+                oauthId: authManager.currentAppleId,
                 memberName: nickname,
                 memberBirthday: formattedBirthday,
-                memberIncome: incomeValue
+                memberIncome: incomeValue,
+                oauthProvider: "apple"
             )
             
         case .none:
@@ -209,9 +213,11 @@ class ProfileSettingViewModel: ObservableObject {
             return MemberInfo(
                 kakaoId: nil,
                 appleId: nil,
+                oauthId: nil,
                 memberName: nickname,
                 memberBirthday: formattedBirthday,
-                memberIncome: incomeValue
+                memberIncome: incomeValue,
+                oauthProvider: "none"
             )
         }
     }
@@ -228,10 +234,12 @@ class ProfileSettingViewModel: ObservableObject {
         let formattedBirthday = convertDateFormat(selectedDate)
         return MemberInfo(
             kakaoId: nil,
-            appleId: apple,
+            appleId: nil,
+            oauthId: apple,
             memberName: nickname,
             memberBirthday: formattedBirthday,
-            memberIncome: incomeValue
+            memberIncome: incomeValue,
+            oauthProvider: "apple"
         )
     }
     


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
- 바뀐 서버 응당구조 및 카카오로그인 방식을 적용하고, 콘텐츠 불러오기 API 구현 및 View 바인딩 작업을 진행했습니다.

## 🎫 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- Contents API 구현 및 화면 연동 작업 진행
- 바뀐 서버 Response 구조 적용
- 카카오 바뀐 로그인 응답방식 적용

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->

- 서버 Response 구조가 바뀌었으나, BaseResPonse를 구현하고 제네릭타입으로 유연하게 적용시켜두어서 수정할때 편리했습니다. 이렇게 설계 구조를 정확하게 잡고 가는것이 중요하다는 것을 다시한번 느낄 수 있었습니다.
- 카카오, 애플 로그인 통합구조로 된것 코드 안쓰는 부분 정리가 필요할 것 같아서 일단 기능 구현 다 완료되면 리팩토링 진행하겠습니다.


## 🎫 Screenshot
|    구현 내용    |    Light Mode    |    Dark Mode    |
| :-------------: | :--------------: | :-------------: |
|       GIF       | <img src = "https://github.com/user-attachments/assets/69206c5f-ce85-48df-8659-69222ff75ef9" width ="250"> | <img src = "https://github.com/user-attachments/assets/75c6babe-40a1-49e7-b286-b384d1713679" width ="250"> |

## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- HomeContentView 에 해당 콘텐츠 누르면 Detail로 넘어가는 부분에서(ContentsCardView),  HomeAPI 를 받으면 해당 ContentID를 넘겨주는 방식으로 수정이 필요할 것 같습니다. 현재 제가 임의로 공백문자열로 만들어두었는데 확인 한번만 부탁드립니다.
```swift
 Button(action : {
     router.push(to : .contentDetailView(contentId: ""))
    }) 
```
- Home에서 일정 불러오는것이 Contents 에서 같이 하는건줄 알고 작업을 같이해버렸네요. 이거는 추후에 Home 관련 API Service로 이전하는것을 생각해봐야 할 듯 싶네요.



## 🖥️ 주요 코드 설명
<!-- 주요 코드에 대한 설명을 작성해주세요. -->
`BaseResponse`
- BaseResponse 응답구조가 바뀌었습니다.
```swift
struct BaseResponse<T: Codable>: Codable {
    let status: Int
    let code: String
    let message: String
    let data: T?
    
    var isSuccess: Bool {
        return status >= 200 && status < 300
    }
}
```

`KakaoLoginManager`
- login 에서 기존 accessToken 전송에서 idToken 값 주는것으로 바뀌었습니다.
```swift
func login() async throws -> String {
    return try await withCheckedThrowingContinuation { continuation in
        if UserApi.isKakaoTalkLoginAvailable() {
            UserApi.shared.loginWithKakaoTalk { oauthToken, error in
                if let error = error {
                    continuation.resume(throwing: error)
                } else if let idToken = oauthToken?.idToken {
                    continuation.resume(returning: idToken)
                }
            }
        } else {
            UserApi.shared.loginWithKakaoAccount { oauthToken, error in
                if let error = error {
                    continuation.resume(throwing: error)
                } else if let idToken = oauthToken?.idToken {
                    continuation.resume(returning: idToken)
                }
            }
        }
    }
}
```


`ContentsService`
- 콘텐츠 불러오기 API 구현
```swift
class ContentsService: ContentsServiceProtocol {

    private let networkService: NetworkService<ContentsTarget>

    init(networkService: NetworkService<ContentsTarget>) {
        self.networkService = networkService
    }

    func getHomeContents() async throws -> ContentsHomeResponse {
        return try await networkService.request(
            .getContentsHome,
            responseType: ContentsHomeResponse.self
        )
        .async()
    }

    func getMoreContents(page: Int, category: String?) async throws -> MoreContentsResponse {
        return try await networkService.request(
            .getContentsCategory(page: page, category: category),
            responseType: MoreContentsResponse.self
        )
        .async()
    }

    func getMoreContentsDetail(contentId: String) async throws -> MoreContentsDetailResponse {
        return try await networkService.request(
            .getContentsDetail(contentId: contentId),
            responseType: MoreContentsDetailResponse.self
        )
        .async()
    }
}
```

## ✅ Check List
- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #152 
